### PR TITLE
Add task.then() which can handle both fulfilled & rejected.

### DIFF
--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -187,6 +187,36 @@ class SwiftTaskTests: _TestCase
         self.wait()
     }
     
+    func testFulfill_then2()
+    {
+        typealias Task = SwiftTask.Task<Float, String, ErrorString>
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        Task { (progress, fulfill, reject, configure) in
+            
+            self.perform {
+                fulfill("OK")
+            }
+            
+        }.then { (value: String?, errorInfo: Task.ErrorInfo?) -> String in
+            // thenClosure can handle both fulfilled & rejected
+                
+            XCTAssertEqual(value!, "OK")
+            XCTAssertTrue(errorInfo == nil)
+            return "OK2"
+                
+        }.then { (value: String?, errorInfo: Task.ErrorInfo?) -> Void in
+                
+            XCTAssertEqual(value!, "OK2")
+            XCTAssertTrue(errorInfo == nil)
+            expect.fulfill()
+                
+        }
+        
+        self.wait()
+    }
+    
     //--------------------------------------------------
     // MARK: - Reject
     //--------------------------------------------------
@@ -334,6 +364,38 @@ class SwiftTaskTests: _TestCase
             
             expect.fulfill()
             
+        }
+        
+        self.wait()
+    }
+    
+    func testReject_then2()
+    {
+        typealias Task = SwiftTask.Task<Float, String, ErrorString>
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        Task { (progress, fulfill, reject, configure) in
+            
+            self.perform {
+                reject("ERROR")
+            }
+            
+        }.then { (value: String?, errorInfo: Task.ErrorInfo?) -> String in
+            // thenClosure can handle both fulfilled & rejected
+            
+            XCTAssertTrue(value == nil)
+            XCTAssertEqual(errorInfo!.error!, "ERROR")
+            XCTAssertFalse(errorInfo!.isCancelled)
+            
+            return "OK"
+            
+        }.then { (value: String?, errorInfo: Task.ErrorInfo?) -> Void in
+            
+            XCTAssertEqual(value!, "OK")
+            XCTAssertTrue(errorInfo == nil)
+            expect.fulfill()
+                
         }
         
         self.wait()


### PR DESCRIPTION
Current `task.then(_ closure:)` method invokes `closure` only when `task` was fulfilled,
but this is not a good idea compared to ES6-Promise's spec as decribed in 
[JavaScript Promises: There and back again - HTML5 Rocks](http://www.html5rocks.com/en/tutorials/es6/promises/), i.e.

```
promise.then(onFulfilled, onRejected)
```

The reason is that we can't establish the same behavior just by chaining fulfilled-only `then` and rejected-only `catch`.

So I also implement above method in a form:

```
public func then<Value2>(thenClosure: (Value?, ErrorInfo?) -> Value2) -> Task<Progress, Value2, Error>

public func then<Progress2, Value2>(thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error>) -> Task<Progress2, Value2, Error>
```

Since `SwiftTask` heavily uses generics, it is smarter to combine `onFulfilled` and `onRejected` handlers into single `thenClosure` so that we don't have to specify long type twice.
