### PR TITLE
Add retryable feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 SwiftTask
 =========
 
-[Promise](http://www.html5rocks.com/en/tutorials/es6/promises/) + progress + pause + cancel, using [SwiftState](https://github.com/inamiy/SwiftState) (state machine).
+[Promise](http://www.html5rocks.com/en/tutorials/es6/promises/) + progress + pause + cancel + retry, using [SwiftState](https://github.com/inamiy/SwiftState) (state machine).
 
 ![SwiftTask](Screenshots/diagram.png)
+
+### Ver 2.1.0 Changelog (2014/12/05)
+
+- added **retryable** feature `try()`
 
 ### Ver 2.0.0 Changelog (2014/11/18)
 
@@ -108,12 +112,30 @@ task.progress { (oldProgress: Progress?, newProgress: Progress) in
 }
 ```
 
+### Retry-able
+
+From ver 2.1.0, `Task` is **retryable** for multiple times by using `try()` method ([Pull Request #9](https://github.com/ReactKit/SwiftTask/pull/9)).
+For example, `task.try(n)` will retry at most `n-1` times if `task` keeps rejected, and `task.try(1)` is obviously same as `task` itself having no retries.
+
+This feature is extremely useful for unstable tasks e.g. network connection.
+By implementing *retryable* from `SwiftTask`'s side, similar code is no longer needed for `player` (inner logic) class.
+
+```swift
+task.try(3).progress { ... }.success { ...
+    // this closure will be called even when task is rejected for 1st & 2nd try
+    // but finally fulfilled in 3rd try.
+}
+
+// shorthand
+(task ~ 3).then { ... }
+```
+
 For more examples, please see XCTest cases.
 
 
 ## API Reference
 
-### Task.init(closure:)
+### Task.init(initClosure:)
 
 Define your `task` inside `initClosure`.
 
@@ -242,6 +264,10 @@ task.success { (value: String) -> Void in
     return
 }
 ```
+
+### task.try(_ tryCount:) -> newTask
+
+See [Retry-able section](#retry-able).
 
 ### Task.all(_ tasks:) -> newTask
 

--- a/SwiftTaskTests/RetainCycleTests.swift
+++ b/SwiftTaskTests/RetainCycleTests.swift
@@ -13,9 +13,14 @@ class Player
 {
     var completionHandler: (Void -> Void)?
     
+    init()
+    {
+        println("[init] \(self)")
+    }
+    
     deinit
     {
-        println("deinit: Player")
+        println("[deinit] \(self)")
     }
     
     func doSomething(completion: (Void -> Void)? = nil)

--- a/SwiftTaskTests/RetainCycleTests.swift
+++ b/SwiftTaskTests/RetainCycleTests.swift
@@ -90,10 +90,10 @@ class RetainCycleTests: _TestCase
             
         }
         
-        self.wait {
-            XCTAssertNil(self.task)
-            XCTAssertNil(self.player)
-        }
+        self.wait()
+        
+        XCTAssertNil(self.task)
+        XCTAssertNil(self.player)
     }
     
     func testPlayer_completionAsArgument_configured()
@@ -136,10 +136,10 @@ class RetainCycleTests: _TestCase
             
         }
         
-        self.wait {
-            XCTAssertNil(self.task)
-            XCTAssertNil(self.player)
-        }
+        self.wait()
+        
+        XCTAssertNil(self.task)
+        XCTAssertNil(self.player)
     }
     
     func testPlayer_completionAsStoredProperty_notConfigured()
@@ -178,10 +178,10 @@ class RetainCycleTests: _TestCase
             
         }
         
-        self.wait {
-            XCTAssertNil(self.task)
-            XCTAssertNil(self.player)
-        }
+        self.wait()
+        
+        XCTAssertNil(self.task)
+        XCTAssertNil(self.player)
     }
     
     func testPlayer_completionAsStoredProperty_configured()
@@ -222,9 +222,9 @@ class RetainCycleTests: _TestCase
             
         }
         
-        self.wait {
-            XCTAssertNil(self.task)
-            XCTAssertNil(self.player)
-        }
+        self.wait()
+    
+        XCTAssertNil(self.task)
+        XCTAssertNil(self.player)
     }
 }

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -444,14 +444,12 @@ class SwiftTaskTests: _TestCase
             
             if self.isAsync {
                 // 0.0 <= progress <= 1.0
-//                XCTAssertGreaterThanOrEqual(newProgress, 0)  // TODO: Xcode6.1-GM bug
-//                XCTAssertLessThanOrEqual(newProgress, 1)     // TODO: Xcode6.1-GM bug
                 XCTAssertTrue(newProgress >= 0)
                 XCTAssertTrue(newProgress <= 1)
                 
-                // 1 <= progressCount <= 5
+                // 1 <= progressCount <= 2
                 XCTAssertGreaterThanOrEqual(progressCount, 1)
-                XCTAssertLessThanOrEqual(progressCount, 5)
+                XCTAssertLessThanOrEqual(progressCount, 2)
             }
             else {
                 XCTFail("When isAsync=false, 1st task closure is already performed before registering this progress closure, so this closure should not be reached.")
@@ -475,14 +473,103 @@ class SwiftTaskTests: _TestCase
         self.wait()
     }
     
+    func testProgress_async_then()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var progressCount = 0
+        
+        let task = self._interruptableTask()    // 1st async task (5 progresses)
+        
+        // chain async-task with then
+        let task3 = task.then { [weak self] _ -> _InterruptableTask in
+            let task2 = self!._interruptableTask()    // 2st async task (5 progresses)
+            return task2
+        }
+        
+        task3.progress { progressValues in
+            progressCount++
+            println(progressValues)
+            return
+        }.success { value -> Void in
+            XCTAssertEqual(value, "OK")
+            XCTAssertEqual(progressCount, 10, "`task3` should receive progresses from `task` & `task2`, so total `progressCount` should be 5 + 5 = 10 on task3-fulfilled.")
+            expect.fulfill()
+        }
+        
+        self.wait()
+    }
+    
+    func testProgress_async_success()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var progressCount = 0
+        
+        let task = self._interruptableTask()    // 1st async task (5 progresses)
+        
+        // chain async-task with success
+        let task3 = task.success { [weak self] _ -> _InterruptableTask in
+            let task2 = self!._interruptableTask()    // 2st async task (5 progresses)
+            return task2
+        }
+        
+        task3.progress { progressValues in
+            progressCount++
+            println(progressValues)
+            return
+            }.success { value -> Void in
+                XCTAssertEqual(value, "OK")
+                XCTAssertEqual(progressCount, 10, "`task3` should receive progresses from `task` & `task2`, so total `progressCount` should be 5 + 5 = 10 on task3-fulfilled.")
+                expect.fulfill()
+        }
+        
+        self.wait()
+    }
+    
+    func testProgress_async_failure()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var progressCount = 0
+        
+        let task = self._interruptableTask(.Rejected)    // 1st async task (5 progresses -> rejected)
+        
+        // chain async-task with failure
+        let task3 = task.failure { [weak self] _ -> _InterruptableTask in
+            let task2 = self!._interruptableTask()    // 2st async task (5 progresses)
+            return task2
+        }
+        
+        task3.progress { progressValues in
+            progressCount++
+            println(progressValues)
+            return
+        }.success { value -> Void in
+            XCTAssertEqual(value, "OK")
+            XCTAssertEqual(progressCount, 10, "`task3` should receive progresses from `task` & `task2`, so total `progressCount` should be 5 + 5 = 10 on task3-fulfilled.")
+            expect.fulfill()
+        }
+        
+        self.wait()
+    }
+    
     //--------------------------------------------------
     // MARK: - Cancel
     //--------------------------------------------------
     
-    // 1. 3 progresses at t=200ms
-    // 2. checks cancel & pause, add 2 progresses at t=400ms
     typealias _InterruptableTask = Task<Float, String, ErrorString>
-    func _interruptableTask() -> _InterruptableTask
+    
+    /// 1. 3 progresses at t=0.2
+    /// 2. checks cancel & pause at t=0.4
+    /// 3. add 2 progresses & fulfill with "OK" or reject with "ERROR" at t=0.4~ (if not paused)
+    func _interruptableTask(_ finalState: TaskState = .Fulfilled) -> _InterruptableTask
     {
         return Task<Float, String, ErrorString> { progress, fulfill, reject, configure in
             
@@ -490,30 +577,37 @@ class SwiftTaskTests: _TestCase
             var isCancelled = false
             var isPaused = false
             
-            // 1st delay (t=200ms)
+            // 1st delay (t=0.2)
             Async.background(after: 0.2) {
                 
                 Async.main { progress(0.0) }
                 Async.main { progress(0.2) }
                 Async.main { progress(0.5) }
                 
-                // 2nd delay (t=400ms)
+                // 2nd delay (t=0.4)
                 Async.background(after: 0.2) {
                     
                     // NOTE: no need to call reject() because it's already rejected (cancelled) internally
                     if isCancelled { return }
                     
                     while isPaused {
+                        println("pausing...")
                         NSThread.sleepForTimeInterval(0.1)
                     }
                     
                     Async.main { progress(0.8) }
                     Async.main { progress(1.0) }
-                    Async.main { fulfill("OK") }
+                    Async.main {
+                        if finalState == .Fulfilled {
+                            fulfill("OK")
+                        }
+                        else {
+                            reject("ERROR")
+                        }
+                    }
                 }
             }
             
-            // configure pause & cancel
             configure.pause = {
                 isPaused = true;
                 return
@@ -522,8 +616,6 @@ class SwiftTaskTests: _TestCase
                 isPaused = false;
                 return
             }
-            
-            // configure cancel for cleanup after reject or task.cancel()
             configure.cancel = {
                 isCancelled = true;
                 return
@@ -544,8 +636,6 @@ class SwiftTaskTests: _TestCase
             progressCount++
             
             // 0.0 <= progress <= 0.5 (not 1.0)
-//            XCTAssertGreaterThanOrEqual(newProgress, 0)  // TODO: Xcode6.1-GM bug
-//            XCTAssertLessThanOrEqual(newProgress, 0.5)   // TODO: Xcode6.1-GM bug
             XCTAssertTrue(newProgress >= 0)
             XCTAssertTrue(newProgress <= 0.5)
             
@@ -568,7 +658,7 @@ class SwiftTaskTests: _TestCase
                 
         }
         
-        // cancel at time between 1st & 2nd delay (t=300ms)
+        // cancel at time between 1st & 2nd delay (t=0.3)
         Async.main(after: 0.3) {
             
             task.cancel(error: "I get bored.")
@@ -605,7 +695,7 @@ class SwiftTaskTests: _TestCase
             return "DUMMY"
         }
         
-        // cancel task3 at time between task1 fulfilled & before task2 completed (t=600ms)
+        // cancel task3 at time between task1 fulfilled & before task2 completed (t=0.6)
         Async.main(after: 0.6) {
             
             task3.cancel(error: "I get bored.")
@@ -647,24 +737,172 @@ class SwiftTaskTests: _TestCase
             
         }
         
-        // pause at time between 1st & 2nd delay (t=300ms)
+        // pause at time between _interruptableTask's 1st & 2nd delay (t=0.3)
         Async.main(after: 0.3) {
             
             task.pause()
             
             XCTAssertEqual(task.state, TaskState.Paused)
-//            XCTAssertEqual(task.progress!, 0.5)   // TODO: Xcode6.1-GM bug
-            XCTAssertTrue(task.progress! == 0.5)
+            XCTAssertTrue(task.progress? == 0.5)
             
-            // resume after 300ms (t=600ms)
+            // resume after 0.3sec (t=0.6)
             Async.main(after: 0.3) {
                 
                 XCTAssertEqual(task.state, TaskState.Paused)
-//                XCTAssertEqual(task.progress!, 0.5)   // TODO: Xcode6.1-GM bug
-                XCTAssertTrue(task.progress! == 0.5)
+                XCTAssertTrue(task.progress? == 0.5)
                 
                 task.resume()
                 XCTAssertEqual(task.state, TaskState.Running)
+                
+            }
+        }
+        
+        self.wait()
+    }
+    
+    func testPauseResume_async_then()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let task = self._interruptableTask()
+        
+        // chain async-task with then
+        let task2 = task.then { [weak self] _ -> _InterruptableTask in
+            return self!._interruptableTask()
+        }
+        
+        task2.success { value -> Void in
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+        }
+        
+        // pause at time between _interruptableTask's 1st & 2nd delay (t=0.3)
+        Async.main(after: 0.3) {
+            
+            // NOTE: parentTask should also be paused (if not, `task` will never be fulfilled/rejected)
+            task2.pause()
+            
+            XCTAssertEqual(task2.state, TaskState.Paused)
+            XCTAssertTrue(task2.progress? == 0.5)
+            
+            XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+            XCTAssertTrue(task.progress? == 0.5)
+            
+            // resume after 0.3sec (t=0.6)
+            Async.main(after: 0.3) {
+                
+                XCTAssertEqual(task2.state, TaskState.Paused)
+                XCTAssertTrue(task2.progress? == 0.5)
+                
+                XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+                XCTAssertTrue(task.progress? == 0.5)
+                
+                task2.resume()
+                XCTAssertEqual(task2.state, TaskState.Running)
+                XCTAssertEqual(task.state, TaskState.Running, "Parent task should also be resumed.")
+                
+            }
+        }
+        
+        self.wait()
+    }
+    
+    func testPauseResume_async_success()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let task = self._interruptableTask()
+        
+        // chain async-task with success
+        let task2 = task.success { [weak self] _ -> _InterruptableTask in
+            return self!._interruptableTask()
+        }
+        
+        task2.success { value -> Void in
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+        }
+        
+        // pause at time between _interruptableTask's 1st & 2nd delay (t=0.3)
+        Async.main(after: 0.3) {
+            
+            // NOTE: parentTask should also be paused (if not, `task` will never be fulfilled/rejected)
+            task2.pause()
+            
+            XCTAssertEqual(task2.state, TaskState.Paused)
+            XCTAssertTrue(task2.progress? == 0.5)
+            
+            XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+            XCTAssertTrue(task.progress? == 0.5)
+            
+            // resume after 0.3sec (t=0.6)
+            Async.main(after: 0.3) {
+                
+                XCTAssertEqual(task2.state, TaskState.Paused)
+                XCTAssertTrue(task2.progress? == 0.5)
+                
+                XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+                XCTAssertTrue(task.progress? == 0.5)
+                
+                task2.resume()
+                XCTAssertEqual(task2.state, TaskState.Running)
+                XCTAssertEqual(task.state, TaskState.Running, "Parent task should also be resumed.")
+                
+            }
+        }
+        
+        self.wait()
+    }
+
+    func testPauseResume_async_failure()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        let task = self._interruptableTask()
+        
+        // chain async-task with failure
+        let task2 = task.failure { [weak self] _ -> _InterruptableTask in
+            return self!._interruptableTask()
+        }
+            
+        task2.success { value -> Void in
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+        }
+        
+        // pause at time between _interruptableTask's 1st & 2nd delay (t=0.3)
+        Async.main(after: 0.3) {
+            
+            // NOTE: parentTask should also be paused (if not, `task` will never be fulfilled/rejected)
+            task2.pause()
+            
+            XCTAssertEqual(task2.state, TaskState.Paused)
+            XCTAssertTrue(task2.progress? == 0.5)
+            
+            XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+            XCTAssertTrue(task.progress? == 0.5)
+            
+            // resume after 0.3sec (t=0.6)
+            Async.main(after: 0.3) {
+                
+                XCTAssertEqual(task2.state, TaskState.Paused)
+                XCTAssertTrue(task2.progress? == 0.5)
+                
+                XCTAssertEqual(task.state, TaskState.Paused, "Parent task should also be paused.")
+                XCTAssertTrue(task.progress? == 0.5)
+                
+                task2.resume()
+                XCTAssertEqual(task2.state, TaskState.Running)
+                XCTAssertEqual(task.state, TaskState.Running, "Parent task should also be resumed.")
                 
             }
         }
@@ -678,20 +916,21 @@ class SwiftTaskTests: _TestCase
     
     func testTry_success()
     {
-        // NOTE: async only
+        // NOTE: this is async test
         if !self.isAsync { return }
         
         var expect = self.expectationWithDescription(__FUNCTION__)
         var tryCount = 3
-        var completeCount = 0
+        var actualTryCount = 0
         
         Task<Float, String, ErrorString> { progress, fulfill, reject, configure in
             
             self.perform {
-                completeCount++
                 
-                if completeCount < tryCount {
-                    reject("ERROR \(completeCount)")
+                actualTryCount++
+                
+                if actualTryCount < tryCount {
+                    reject("ERROR \(actualTryCount)")
                 }
                 else {
                     fulfill("OK")
@@ -716,20 +955,23 @@ class SwiftTaskTests: _TestCase
     
     func testTry_failure()
     {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
         var expect = self.expectationWithDescription(__FUNCTION__)
         var tryCount = 3
-        var completeCount = 0
+        var actualTryCount = 0
         
         let t = Task<Float, String, ErrorString> { progress, fulfill, reject, configure in
             
             self.perform {
-                completeCount++
-                reject("ERROR \(completeCount)")
+                actualTryCount++
+                reject("ERROR \(actualTryCount)")
             }
             
         }.try(tryCount).failure { error, isCancelled -> String in
             
-            XCTAssertEqual(error!, "ERROR \(completeCount)")
+            XCTAssertEqual(error!, "ERROR \(actualTryCount)")
             XCTAssertFalse(isCancelled)
             
             expect.fulfill()
@@ -739,6 +981,117 @@ class SwiftTaskTests: _TestCase
         }
         
         self.wait()
+    }
+    
+    func testTry_progress()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var tryCount = 3
+        var actualTryCount = 0
+        var progressCount = 0
+        
+        Task<Float, String, ErrorString> { progress, fulfill, reject, configure in
+            
+            self.perform {
+                
+                progress(1.0)
+                
+                actualTryCount++
+                
+                if actualTryCount < tryCount {
+                    reject("ERROR \(actualTryCount)")
+                }
+                else {
+                    fulfill("OK")
+                }
+            }
+            
+        }.try(tryCount).progress { _ in
+            
+            progressCount++
+            
+            // 1 <= progressCount <= tryCount
+            XCTAssertGreaterThanOrEqual(progressCount, 1)
+            XCTAssertLessThanOrEqual(progressCount, tryCount)
+            
+        }.success { value -> Void in
+            
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+                
+        }
+        
+        self.wait()
+        
+        XCTAssertEqual(progressCount, tryCount)
+    }
+    
+    func testTry_pauseResume()
+    {
+        // NOTE: this is async test
+        if !self.isAsync { return }
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var tryCount = 5
+        var actualTryCount = 0
+        
+        let retryableTask = Task<Float, String, ErrorString> { progress, fulfill, reject, configure in
+            
+            actualTryCount++
+            println("trying \(actualTryCount)")
+            
+            var isPaused = false
+            
+            Async.background(after: 0.1) {
+                while isPaused {
+                    println("pausing...")
+                    NSThread.sleepForTimeInterval(0.1)
+                }
+                Async.main(after: 0.2) {
+                    if actualTryCount < tryCount {
+                        reject("ERROR \(actualTryCount)")
+                    }
+                    else {
+                        fulfill("OK")
+                    }
+                }
+            }
+            
+            configure.pause = {
+                isPaused = true
+                return
+            }
+            configure.resume = {
+                isPaused = false
+                return
+            }
+            
+        }.try(tryCount)
+        
+        retryableTask.success { value -> Void in
+            
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+            
+        }
+        
+        // pause `retryableTask` at some point
+        Async.main(after: 0.5) {
+            retryableTask.pause()
+            return
+        }
+        
+        Async.main(after: 1.5) {
+            retryableTask.resume()
+            return
+        }
+        
+        self.wait(5)    // wait a little longer
+        
+        XCTAssertEqual(actualTryCount, tryCount)
     }
     
     //--------------------------------------------------

--- a/SwiftTaskTests/_TestCase.swift
+++ b/SwiftTaskTests/_TestCase.swift
@@ -25,15 +25,10 @@ class _TestCase: XCTestCase
         super.tearDown()
     }
     
-    func wait(handler: (Void -> Void)? = nil)
+    func wait(_ timeout: NSTimeInterval = 3)
     {
-        self.waitForExpectationsWithTimeout(3) { error in
-            
+        self.waitForExpectationsWithTimeout(timeout) { error in
             println("wait error = \(error)")
-            
-            if let handler = handler {
-                handler()
-            }
         }
     }
     


### PR DESCRIPTION
This pull request brings a new **retryable** feature for future ver 2.1.0.

`task.try(n)` returns a new task that is retryable for `n-1` times, and is conceptually equal to

```
task.failure(clonedTask1).failure(clonedTask2)...
```

with n-1 failure-able.
### Usage

```
task.try(3).success { ...
    // this closure will be called even when task is rejected for 1st & 2nd try 
    // but fulfilled in 3rd try.
}

// shorthand
(task ~ 3).then { ... }
```
