### PR TITLE
Fix 4dcdfcc xcworkspace.

### DIFF
--- a/SwiftTask.xcworkspace/contents.xcworkspacedata
+++ b/SwiftTask.xcworkspace/contents.xcworkspacedata
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
-   <FileRef
-      location = "group:Carthage.checkout">
-   </FileRef>
+   <Group
+      location = "group:Carthage.checkout"
+      name = "Carthage.checkout">
+      <FileRef
+         location = "group:SwiftState/SwiftState.xcodeproj">
+      </FileRef>
+   </Group>
    <FileRef
       location = "group:SwiftTask.xcodeproj">
    </FileRef>


### PR DESCRIPTION
Continuing #11 & #12.

Drag-and-dropping Carthage.checkout folder to xcworkspace as "Create folder references for any added folders" will mix up OSX/iOS xcodebuild when `carthage build` from depending project e.g. [ReactKit](https://github.com/ReactKit/ReactKit).

```
Build settings from command line:
    SDKROOT = iphoneos8.1

=== BUILD TARGET SwiftState-OSX OF PROJECT SwiftState WITH CONFIGURATION Release ===

Check dependencies
CodeSign error: code signing is required for product type 'Framework' in SDK 'iOS 8.1'
```
