### PR TITLE
Swift 1.2 Support

### DIFF
--- a/SwiftTask.xcodeproj/project.pbxproj
+++ b/SwiftTask.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F20250119ADA8FD00DE0495 /* BasicTests.swift */; };
-		1F2C0C1C1A32A15300CFBB47 /* AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5FA35619A374E600975FB9 /* AlamofireTests.swift */; };
-		1F2C0C1D1A32A15300CFBB47 /* AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5FA35619A374E600975FB9 /* AlamofireTests.swift */; };
 		1F46DEDA199EDF1000F97868 /* SwiftTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F46DED9199EDF1000F97868 /* SwiftTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F46DEFB199EDF8100F97868 /* SwiftTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFA199EDF8100F97868 /* SwiftTask.swift */; };
 		1F46DEFD199EE2C200F97868 /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFC199EE2C200F97868 /* _TestCase.swift */; };
@@ -20,8 +18,6 @@
 		4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F20250119ADA8FD00DE0495 /* BasicTests.swift */; };
 		4822F0DE19D00B2300F5F572 /* SwiftTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEE3199EDF1000F97868 /* SwiftTaskTests.swift */; };
 		4822F0E019D00B2300F5F572 /* RetainCycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48511C5A19C17563002FE03C /* RetainCycleTests.swift */; };
-		484552321A4CF37F007770CA /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484551CE1A4CF37F007770CA /* Alamofire.swift */; };
-		484552331A4CF37F007770CA /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484551CE1A4CF37F007770CA /* Alamofire.swift */; };
 		4845524A1A4CF37F007770CA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484551DC1A4CF37F007770CA /* Async.swift */; };
 		4845524B1A4CF37F007770CA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484551DC1A4CF37F007770CA /* Async.swift */; };
 		48511C5B19C17563002FE03C /* RetainCycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48511C5A19C17563002FE03C /* RetainCycleTests.swift */; };
@@ -369,11 +365,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				4845524A1A4CF37F007770CA /* Async.swift in Sources */,
-				484552321A4CF37F007770CA /* Alamofire.swift in Sources */,
 				1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */,
 				1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
 				1F6A8CA319A4E4F200369A5D /* SwiftTaskTests.swift in Sources */,
-				1F2C0C1C1A32A15300CFBB47 /* AlamofireTests.swift in Sources */,
 				485C31F11A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,
 				48511C5B19C17563002FE03C /* RetainCycleTests.swift in Sources */,
 				1F46DEFD199EE2C200F97868 /* _TestCase.swift in Sources */,
@@ -385,11 +379,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				4845524B1A4CF37F007770CA /* Async.swift in Sources */,
-				484552331A4CF37F007770CA /* Alamofire.swift in Sources */,
 				4822F0DE19D00B2300F5F572 /* SwiftTaskTests.swift in Sources */,
 				4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */,
 				1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
-				1F2C0C1D1A32A15300CFBB47 /* AlamofireTests.swift in Sources */,
 				485C31F21A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,
 				4822F0DC19D00B2300F5F572 /* _TestCase.swift in Sources */,
 				4822F0E019D00B2300F5F572 /* RetainCycleTests.swift in Sources */,

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -125,7 +125,7 @@ public class Task<Progress, Value, Error>: Printable
             initClosure(progress: progress, fulfill: fulfill, reject: { (error: Error?) in _reject(ErrorInfo(error: error, isCancelled: false)) }, configure: configure)
         }
         
-        self.setup(weakified, paused: paused, _initClosure)
+        self.setup(weakified, paused: paused, _initClosure: _initClosure)
     }
     
     ///
@@ -194,7 +194,7 @@ public class Task<Progress, Value, Error>: Printable
         self._paused = paused
         self._machine = _Machine(paused: paused)
         
-        self.setup(weakified, paused: paused, _initClosure)
+        self.setup(weakified, paused: paused, _initClosure: _initClosure)
     }
     
     internal func setup(weakified: Bool, paused: Bool, _initClosure: _InitClosure)

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -122,7 +122,7 @@ public class Task<Progress, Value, Error>: Printable
         
         let _initClosure: _InitClosure = { _, progress, fulfill, _reject, configure in
             // NOTE: don't expose rejectHandler with ErrorInfo (isCancelled) for public init
-            initClosure(progress: progress, fulfill: fulfill, reject: { (error: Error?) in _reject(ErrorInfo(error: error, isCancelled: false)) }, configure: configure)
+            initClosure(progress: progress, fulfill: fulfill, reject: { (error: Error) in _reject(ErrorInfo(error: error, isCancelled: false)) }, configure: configure)
         }
         
         self.setup(weakified, paused: paused, _initClosure: _initClosure)

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -679,13 +679,13 @@ class SwiftTaskTests: _TestCase
             task.pause()
             
             XCTAssertEqual(task.state, TaskState.Paused)
-            XCTAssertTrue(task.progress? == 2, "`task` should be progressed halfway.")
+            XCTAssertTrue(task.progress! == 2, "`task` should be progressed halfway.")
             
             // resume at t=0.6
             Async.main(after: 0.3) {
                 
                 XCTAssertEqual(task.state, TaskState.Paused)
-                XCTAssertTrue(task.progress? == 2, "`task` should pause progressing.")
+                XCTAssertTrue(task.progress! == 2, "`task` should pause progressing.")
                 
                 task.resume()
                 
@@ -730,7 +730,7 @@ class SwiftTaskTests: _TestCase
             XCTAssertNil(innerTask, "`innerTask` should NOT be created yet.")
             
             XCTAssertEqual(task.state, TaskState.Running, "`task` should NOT be paused.")
-            XCTAssertTrue(task.progress? == 2, "`task` should be halfway progressed.")
+            XCTAssertTrue(task.progress! == 2, "`task` should be halfway progressed.")
             XCTAssertNil(task.value, "`task` should NOT be fulfilled yet.")
             
             // resume at t=0.6


### PR DESCRIPTION
This pull request will migrate **test** code to Swift 1.2 (Xcode 6.3).
Fortunately, there is no change in core codes.

See also: https://github.com/ReactKit/SwiftTask/issues/25