### PR TITLE
[Playground] Add examples.

### DIFF
--- a/Playgrounds/01-Sync.playground/Contents.swift
+++ b/Playgrounds/01-Sync.playground/Contents.swift
@@ -1,0 +1,79 @@
+//: Playground - noun: a place where people can play
+
+import Cocoa
+import XCPlayground
+
+//
+// NOTE: custom framework needs to be built first (and restart Xcode if needed)
+//
+// Importing Custom Frameworks Into a Playground
+// https://developer.apple.com/library/prerelease/ios/recipes/Playground_Help/Chapters/ImportingaFrameworkIntoaPlayground.html
+//
+import SwiftTask
+
+typealias Progress = Float
+typealias Value = String
+typealias Error = NSError
+
+typealias MyTask = Task<Progress, Value, Error>
+
+let myError = NSError(domain: "MyErrorDomain", code: 0, userInfo: nil)
+
+//--------------------------------------------------
+// Example 1: Sync fulfilled -> success
+//--------------------------------------------------
+
+let task = MyTask(value: "Hello")
+    .success { value -> String in
+        return "\(value) World"
+    }
+    .success { value -> String in
+        return "\(value)!!!"
+    }
+
+task.value
+
+//--------------------------------------------------
+// Example 2: Sync rejected -> success -> failure
+//--------------------------------------------------
+
+let task2a = MyTask(error: myError)
+    .success { value -> String in
+        return "Never reaches here..."
+    }
+let task2b = task2a
+    .failure { error, isCancelled -> String in
+        return "ERROR: \(error!.domain)"    // recovery from failure
+    }
+
+task2a.value
+task2a.errorInfo
+task2b.value
+task2b.errorInfo
+
+//--------------------------------------------------
+// Example 3: Sync fulfilled or rejected -> then
+//--------------------------------------------------
+
+// fulfills or rejects immediately
+let task3a = MyTask { progress, fulfill, reject, configure in
+    if arc4random_uniform(2) == 0 {
+        fulfill("Hello")
+    }
+    else {
+        reject(myError)
+    }
+}
+let task3b = task3a
+    .then { value, errorInfo -> String in
+        if let errorInfo = errorInfo {
+            return "ERROR: \(errorInfo.error!.domain)"
+        }
+        
+        return "\(value!) World"
+    }
+
+task3a.value
+task3a.errorInfo
+task3b.value
+task3b.errorInfo

--- a/Playgrounds/01-Sync.playground/Sources/SupportCode.swift
+++ b/Playgrounds/01-Sync.playground/Sources/SupportCode.swift
@@ -1,0 +1,3 @@
+//
+// This file (and all other Swift source files in the Sources directory of this playground) will be precompiled into a framework which is automatically made available to 01-Sync.playground.
+//

--- a/Playgrounds/01-Sync.playground/contents.xcplayground
+++ b/Playgrounds/01-Sync.playground/contents.xcplayground
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='osx'/>

--- a/Playgrounds/02-Async.playground/Contents.swift
+++ b/Playgrounds/02-Async.playground/Contents.swift
@@ -1,0 +1,62 @@
+//: Playground - noun: a place where people can play
+
+import Cocoa
+import XCPlayground
+
+//
+// NOTE: custom framework needs to be built first (and restart Xcode if needed)
+//
+// Importing Custom Frameworks Into a Playground
+// https://developer.apple.com/library/prerelease/ios/recipes/Playground_Help/Chapters/ImportingaFrameworkIntoaPlayground.html
+//
+import SwiftTask
+
+typealias Progress = Float
+typealias Value = String
+typealias Error = NSError
+
+typealias MyTask = Task<Progress, Value, Error>
+
+let myError = NSError(domain: "MyErrorDomain", code: 0, userInfo: nil)
+
+// for async test
+XCPSetExecutionShouldContinueIndefinitely()
+
+// fulfills after 100ms
+func asyncTask(value: String) -> MyTask
+{
+    return MyTask { progress, fulfill, reject, configure in
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100_000_000), dispatch_get_main_queue()) {
+            fulfill(value)
+        }
+    }
+}
+
+//--------------------------------------------------
+// Example 1: Async
+//--------------------------------------------------
+
+let task1a = asyncTask("Hello")
+let task1b = task1a
+    .success { value -> String in
+        return "\(value) World"
+    }
+
+// NOTE: these values should be all nil because task is async
+task1a.value
+task1a.errorInfo
+task1b.value
+task1b.errorInfo
+
+//--------------------------------------------------
+// Example 2: Async chaining
+//--------------------------------------------------
+
+let task2a = asyncTask("Hello")
+let task2b = task2a
+    .success { value -> MyTask in
+        return asyncTask("\(value) Cruel")  // next async
+    }
+    .success { value -> String in
+        return "\(value) World"
+    }

--- a/Playgrounds/02-Async.playground/Sources/SupportCode.swift
+++ b/Playgrounds/02-Async.playground/Sources/SupportCode.swift
@@ -1,0 +1,3 @@
+//
+// This file (and all other Swift source files in the Sources directory of this playground) will be precompiled into a framework which is automatically made available to 02-Async.playground.
+//

--- a/Playgrounds/02-Async.playground/contents.xcplayground
+++ b/Playgrounds/02-Async.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='osx'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Playgrounds/02-Async.playground/timeline.xctimeline
+++ b/Playgrounds/02-Async.playground/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Playgrounds/03-Alamofire.playground/Contents.swift
+++ b/Playgrounds/03-Alamofire.playground/Contents.swift
@@ -1,0 +1,67 @@
+//: Playground - noun: a place where people can play
+
+import Cocoa
+import XCPlayground
+
+//
+// NOTE: custom framework needs to be built first (and restart Xcode if needed)
+//
+// Importing Custom Frameworks Into a Playground
+// https://developer.apple.com/library/prerelease/ios/recipes/Playground_Help/Chapters/ImportingaFrameworkIntoaPlayground.html
+//
+import SwiftTask
+import Alamofire
+
+typealias Progress = (bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)
+typealias Value = String
+typealias Error = NSError
+
+typealias AlamofireTask = Task<Progress, Value, Error>
+
+let myError = NSError(domain: "MyErrorDomain", code: 0, userInfo: nil)
+
+// for async test
+XCPSetExecutionShouldContinueIndefinitely()
+
+//--------------------------------------------------
+// Example 1: Alamofire progress
+//--------------------------------------------------
+
+// define task
+let task = AlamofireTask { progress, fulfill, reject, configure in
+    
+    let request = Alamofire.download(.GET, "http://httpbin.org/stream/100", Request.suggestedDownloadDestination(directory: .DocumentDirectory, domain: .UserDomainMask))
+        
+    request
+        .progress { (bytesWritten, totalBytesWritten, totalBytesExpectedToWrite) in
+            progress((bytesWritten, totalBytesWritten, totalBytesExpectedToWrite) as Progress)
+        }
+        .response { (request, response, data, error) in
+            
+            // print
+            data
+            error?.localizedDescription
+            
+            if let error = error {
+                reject(error)
+                return
+            }
+            
+            fulfill("OK")
+            
+        }
+}
+
+task
+    .progress { oldProgress, newProgress in
+        // print
+        newProgress.bytesWritten
+        newProgress.totalBytesWritten
+    }
+    .then { value, errorInfo -> String in
+        if let errorInfo = errorInfo {
+            return "ERROR: \(errorInfo.error!.domain)"
+        }
+        
+        return "\(value!) World"
+    }

--- a/Playgrounds/03-Alamofire.playground/Sources/SupportCode.swift
+++ b/Playgrounds/03-Alamofire.playground/Sources/SupportCode.swift
@@ -1,0 +1,3 @@
+//
+// This file (and all other Swift source files in the Sources directory of this playground) will be precompiled into a framework which is automatically made available to 03-Alamofire.playground.
+//

--- a/Playgrounds/03-Alamofire.playground/contents.xcplayground
+++ b/Playgrounds/03-Alamofire.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='osx'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Playgrounds/03-Alamofire.playground/timeline.xctimeline
+++ b/Playgrounds/03-Alamofire.playground/timeline.xctimeline
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=1785&amp;EndingColumnNumber=23&amp;EndingLineNumber=58&amp;StartingColumnNumber=9&amp;StartingLineNumber=58&amp;Timestamp=450426052.187599"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1804&amp;EndingColumnNumber=42&amp;EndingLineNumber=58&amp;StartingColumnNumber=9&amp;StartingLineNumber=58&amp;Timestamp=450426052.18781"
+         selectedRepresentationIndex = "1"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=29&amp;CharacterRangeLoc=1776&amp;EndingColumnNumber=38&amp;EndingLineNumber=58&amp;StartingColumnNumber=9&amp;StartingLineNumber=58&amp;Timestamp=450426052.187982"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=24&amp;CharacterRangeLoc=1743&amp;EndingColumnNumber=33&amp;EndingLineNumber=57&amp;StartingColumnNumber=9&amp;StartingLineNumber=57&amp;Timestamp=450426052.188093"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+   </TimelineItems>
+</Timeline>

--- a/SwiftTask.xcworkspace/contents.xcworkspacedata
+++ b/SwiftTask.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,19 @@
 <Workspace
    version = "1.0">
    <Group
+      location = "group:Playgrounds"
+      name = "Playgrounds">
+      <FileRef
+         location = "group:01-Sync.playground">
+      </FileRef>
+      <FileRef
+         location = "group:02-Async.playground">
+      </FileRef>
+      <FileRef
+         location = "group:03-Alamofire.playground">
+      </FileRef>
+   </Group>
+   <Group
       location = "group:Carthage/Checkouts"
       name = "Checkouts">
       <Group


### PR DESCRIPTION
This pull request will add Xcode Playground examples, and also a demo for https://github.com/ReactKit/SwiftTask/pull/28 and https://github.com/ReactKit/SwiftTask/pull/29. 

As commented in [example code](https://github.com/ReactKit/SwiftTask/blob/playground/Playgrounds/03-Alamofire.playground/Contents.swift#L6-L13), please make sure to **build custom frameworks & restart Xcode** first before actual try.

Ref: [Importing Custom Frameworks Into a Playground](https://developer.apple.com/library/prerelease/ios/recipes/Playground_Help/Chapters/ImportingaFrameworkIntoaPlayground.html)