### PR TITLE
Add Canceller for removing progress/then handlers.

### DIFF
--- a/SwiftTask.xcodeproj/project.pbxproj
+++ b/SwiftTask.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		1FCF71141AD8CD2F007079C2 /* Async.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCF71131AD8CD2F007079C2 /* Async.framework */; };
 		1FCF71161AD8CD38007079C2 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCF71151AD8CD38007079C2 /* Alamofire.framework */; };
 		1FCF71181AD8CD3C007079C2 /* Async.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCF71171AD8CD3C007079C2 /* Async.framework */; };
+		1FD7197B1AFE387C00BC38C4 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */; };
+		1FD7197C1AFE387C00BC38C4 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */; };
 		1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */; };
 		1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */; };
 		4822F0DC19D00B2300F5F572 /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFC199EE2C200F97868 /* _TestCase.swift */; };
@@ -53,6 +55,7 @@
 		1FCF71131AD8CD2F007079C2 /* Async.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Async.framework; path = "../Carthage/Checkouts/Async/build/Debug-iphoneos/Async.framework"; sourceTree = "<group>"; };
 		1FCF71151AD8CD38007079C2 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = ../Carthage/Checkouts/Alamofire/build/Debug/Alamofire.framework; sourceTree = "<group>"; };
 		1FCF71171AD8CD3C007079C2 /* Async.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Async.framework; path = ../Carthage/Checkouts/Async/build/Debug/Async.framework; sourceTree = "<group>"; };
+		1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _InterruptableTask.swift; sourceTree = "<group>"; };
 		4822F0D019D00ABF00F5F572 /* SwiftTask-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftTask-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		48511C5A19C17563002FE03C /* RetainCycleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetainCycleTests.swift; sourceTree = "<group>"; };
@@ -124,6 +127,7 @@
 			children = (
 				1F46DED9199EDF1000F97868 /* SwiftTask.h */,
 				1F46DEFA199EDF8100F97868 /* SwiftTask.swift */,
+				1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */,
 				48B58D7A1A6F255E0068E18C /* _StateMachine.swift */,
 				1F46DED7199EDF1000F97868 /* Supporting Files */,
 			);
@@ -339,6 +343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F46DEFB199EDF8100F97868 /* SwiftTask.swift in Sources */,
+				1FD7197B1AFE387C00BC38C4 /* Cancellable.swift in Sources */,
 				48B58D7B1A6F255E0068E18C /* _StateMachine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -378,6 +383,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				48CD5A3C19AEEBDF0042B9F1 /* SwiftTask.swift in Sources */,
+				1FD7197C1AFE387C00BC38C4 /* Cancellable.swift in Sources */,
 				48B58D7C1A6F255E0068E18C /* _StateMachine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftTask.xcodeproj/project.pbxproj
+++ b/SwiftTask.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F20250119ADA8FD00DE0495 /* BasicTests.swift */; };
+		1F218D5B1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */; };
+		1F218D5C1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */; };
 		1F46DEDA199EDF1000F97868 /* SwiftTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F46DED9199EDF1000F97868 /* SwiftTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F46DEFB199EDF8100F97868 /* SwiftTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFA199EDF8100F97868 /* SwiftTask.swift */; };
 		1F46DEFD199EE2C200F97868 /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFC199EE2C200F97868 /* _TestCase.swift */; };
@@ -37,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		1F20250119ADA8FD00DE0495 /* BasicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTests.swift; sourceTree = "<group>"; };
+		1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoveHandlerTests.swift; sourceTree = "<group>"; };
 		1F46DED4199EDF1000F97868 /* SwiftTask.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftTask.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F46DED8199EDF1000F97868 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F46DED9199EDF1000F97868 /* SwiftTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftTask.h; sourceTree = "<group>"; };
@@ -144,6 +147,7 @@
 				1F46DEE3199EDF1000F97868 /* SwiftTaskTests.swift */,
 				48511C5A19C17563002FE03C /* RetainCycleTests.swift */,
 				485C31F01A1D619A00040DA3 /* TypeInferenceTests.swift */,
+				1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */,
 				1F5FA35619A374E600975FB9 /* AlamofireTests.swift */,
 				1F46DEE1199EDF1000F97868 /* Supporting Files */,
 			);
@@ -345,6 +349,7 @@
 			files = (
 				1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */,
 				1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
+				1F218D5B1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
 				1F6A8CA319A4E4F200369A5D /* SwiftTaskTests.swift in Sources */,
 				1F4C76A41AD8CF40004E47C1 /* AlamofireTests.swift in Sources */,
 				485C31F11A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,
@@ -359,6 +364,7 @@
 			files = (
 				4822F0DE19D00B2300F5F572 /* SwiftTaskTests.swift in Sources */,
 				4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */,
+				1F218D5C1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
 				1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
 				1F4C76A51AD8CF41004E47C1 /* AlamofireTests.swift in Sources */,
 				485C31F21A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,

--- a/SwiftTask/Cancellable.swift
+++ b/SwiftTask/Cancellable.swift
@@ -12,7 +12,13 @@ public protocol Cancellable
 {
     typealias Error
     
-    func cancel(error: Error) -> Bool
+    //
+    // NOTE:
+    // Single `func cancel(error: Error) -> Bool` is preferred (as first implemented in 8a22ed5),
+    // but two overloaded methods are required for SwiftTask ver 3.x API compatibility.
+    //
+    func cancel() -> Bool
+    func cancel(#error: Error) -> Bool
 }
 
 public class Canceller: Cancellable
@@ -24,7 +30,12 @@ public class Canceller: Cancellable
         self.cancelHandler = cancelHandler
     }
     
-    public func cancel(error: Void) -> Bool
+    public func cancel() -> Bool
+    {
+        return self.cancel(error: ())
+    }
+    
+    public func cancel(#error: Void) -> Bool
     {
         if let cancelHandler = self.cancelHandler {
             self.cancelHandler = nil

--- a/SwiftTask/Cancellable.swift
+++ b/SwiftTask/Cancellable.swift
@@ -1,0 +1,45 @@
+//
+//  Cancellable.swift
+//  SwiftTask
+//
+//  Created by Yasuhiro Inami on 2015/05/09.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import Foundation
+
+public protocol Cancellable
+{
+    typealias Error
+    
+    func cancel(error: Error) -> Bool
+}
+
+public class Canceller: Cancellable
+{
+    private var cancelHandler: (Void -> Void)?
+    
+    public required init(cancelHandler: Void -> Void)
+    {
+        self.cancelHandler = cancelHandler
+    }
+    
+    public func cancel(error: Void) -> Bool
+    {
+        if let cancelHandler = self.cancelHandler {
+            self.cancelHandler = nil
+            cancelHandler()
+            return true
+        }
+        
+        return false
+    }
+}
+
+public class AutoCanceller: Canceller
+{
+    deinit
+    {
+        self.cancel()
+    }
+}

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -564,10 +564,10 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     //
     public func cancel() -> Bool
     {
-        return self.cancel(nil)
+        return self.cancel(error: nil)
     }
     
-    public func cancel(error: Error?) -> Bool
+    public func cancel(#error: Error?) -> Bool
     {
         return self._cancel(error: error)
     }

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -374,7 +374,8 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
     
     ///
-    /// then (fulfilled & rejected) + closure returning value
+    /// then (fulfilled & rejected) + closure returning **value** 
+    /// (a.k.a. `map` in functional programming term)
     ///
     /// - e.g. task.then { value, errorInfo -> NextValueType in ... }
     ///
@@ -392,7 +393,8 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
     
     ///
-    /// then (fulfilled & rejected) + closure returning task
+    /// then (fulfilled & rejected) + closure returning **task**
+    /// (a.k.a. `flatMap` in functional programming term)
     ///
     /// - e.g. task.then { value, errorInfo -> NextTaskType in ... }
     ///
@@ -402,6 +404,12 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
         return self.then(&dummyCanceller, thenClosure)
     }
     
+    //
+    // NOTE: then-canceller is a shorthand of `task.cancel(nil)`, i.e. these two are the same:
+    //
+    // - `let canceller = Canceller(); task1.then(&canceller) {...}; canceller.cancel();`
+    // - `let task2 = task1.then {...}; task2.cancel();`
+    //
     public func then<Progress2, Value2, C: Canceller>(inout canceller: C?, _ thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error>) -> Task<Progress2, Value2, Error>
     {
         return Task<Progress2, Value2, Error> { [unowned self, weak canceller] newMachine, progress, fulfill, _reject, configure in
@@ -440,7 +448,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
     
     ///
-    /// success (fulfilled) + closure returning value
+    /// success (fulfilled) + closure returning **value**
     ///
     /// - e.g. task.success { value -> NextValueType in ... }
     ///
@@ -458,7 +466,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
     
     ///
-    /// success (fulfilled) + closure returning task
+    /// success (fulfilled) + closure returning **task**
     ///
     /// - e.g. task.success { value -> NextTaskType in ... }
     ///
@@ -489,7 +497,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
     
     ///
-    /// failure (rejected) + closure returning value
+    /// failure (rejected or cancelled) + closure returning **value**
     ///
     /// - e.g. task.failure { errorInfo -> NextValueType in ... }
     /// - e.g. task.failure { error, isCancelled -> NextValueType in ... }
@@ -508,7 +516,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     }
 
     ///
-    /// failure (rejected) + closure returning task
+    /// failure (rejected or cancelled) + closure returning **task**
     ///
     /// - e.g. task.failure { errorInfo -> NextTaskType in ... }
     /// - e.g. task.failure { error, isCancelled -> NextTaskType in ... }

--- a/SwiftTask/_StateMachine.swift
+++ b/SwiftTask/_StateMachine.swift
@@ -41,32 +41,40 @@ internal class _StateMachine<Progress, Value, Error>
         self.state = paused ? .Paused : .Running
     }
     
-    internal func addProgressTupleHandler(inout token: _HandlerToken?, _ progressTupleHandler: ProgressTupleHandler)
+    internal func addProgressTupleHandler(inout token: _HandlerToken?, _ progressTupleHandler: ProgressTupleHandler) -> Bool
     {
         if self.state == .Running || self.state == .Paused {
             token = self.progressTupleHandlers.append(progressTupleHandler)
+            return token != nil
         }
+        return false
     }
     
-    internal func removeProgressTupleHandler(handlerToken: _HandlerToken?)
+    internal func removeProgressTupleHandler(handlerToken: _HandlerToken?) -> Bool
     {
         if let handlerToken = handlerToken {
-            self.progressTupleHandlers.remove(handlerToken)
+            let removedHandler = self.progressTupleHandlers.remove(handlerToken)
+            return removedHandler != nil
         }
+        return false
     }
     
-    internal func addCompletionHandler(inout token: _HandlerToken?, _ completionHandler: Void -> Void)
+    internal func addCompletionHandler(inout token: _HandlerToken?, _ completionHandler: Void -> Void) -> Bool
     {
         if self.state == .Running || self.state == .Paused {
             token = self.completionHandlers.append(completionHandler)
+            return token != nil
         }
+        return false
     }
     
-    internal func removeCompletionHandler(handlerToken: _HandlerToken?)
+    internal func removeCompletionHandler(handlerToken: _HandlerToken?) -> Bool
     {
         if let handlerToken = handlerToken {
-            self.completionHandlers.remove(handlerToken)
+            let removedHandler = self.completionHandlers.remove(handlerToken)
+            return removedHandler != nil
         }
+        return false
     }
     
     internal func handleProgress(progress: Progress)
@@ -224,9 +232,9 @@ internal struct _Handlers<T>: SequenceType
         return _HandlerToken(key: self.currentKey)
     }
     
-    internal mutating func remove(token: _HandlerToken)
+    internal mutating func remove(token: _HandlerToken) -> T?
     {
-        self.elements.removeValueForKey(token.key)
+        return self.elements.removeValueForKey(token.key)
     }
     
     internal mutating func removeAll(keepCapacity: Bool = false)

--- a/SwiftTask/_StateMachine.swift
+++ b/SwiftTask/_StateMachine.swift
@@ -220,21 +220,28 @@ internal struct _HandlerToken
 
 internal struct _Handlers<T>: SequenceType
 {
+    internal typealias KeyValue = (key: Int, value: T)
+    
     private var currentKey: Int = 0
-    private var elements = [Int : T]()
+    private var elements = [KeyValue]()
     
     internal mutating func append(value: T) -> _HandlerToken
     {
         self.currentKey = self.currentKey &+ 1
         
-        self.elements[self.currentKey] = value
+        self.elements += [(key: self.currentKey, value: value)]
         
         return _HandlerToken(key: self.currentKey)
     }
     
     internal mutating func remove(token: _HandlerToken) -> T?
     {
-        return self.elements.removeValueForKey(token.key)
+        for var i = 0; i < self.elements.count; i++ {
+            if self.elements[i].key == token.key {
+                return self.elements.removeAtIndex(i).value
+            }
+        }
+        return nil
     }
     
     internal mutating func removeAll(keepCapacity: Bool = false)
@@ -244,6 +251,6 @@ internal struct _Handlers<T>: SequenceType
     
     internal func generate() -> GeneratorOf<T>
     {
-        return GeneratorOf(self.elements.values.generate())
+        return GeneratorOf(self.elements.map { $0.value }.generate())
     }
 }

--- a/SwiftTask/_StateMachine.swift
+++ b/SwiftTask/_StateMachine.swift
@@ -41,28 +41,32 @@ internal class _StateMachine<Progress, Value, Error>
         self.state = paused ? .Paused : .Running
     }
     
-    internal func addProgressTupleHandler(inout token: HandlerToken?, _ progressTupleHandler: ProgressTupleHandler)
+    internal func addProgressTupleHandler(inout token: _HandlerToken?, _ progressTupleHandler: ProgressTupleHandler)
     {
         if self.state == .Running || self.state == .Paused {
             token = self.progressTupleHandlers.append(progressTupleHandler)
         }
     }
     
-    internal func removeProgressTupleHandler(handlerToken: HandlerToken)
+    internal func removeProgressTupleHandler(handlerToken: _HandlerToken?)
     {
-        self.progressTupleHandlers.remove(handlerToken)
+        if let handlerToken = handlerToken {
+            self.progressTupleHandlers.remove(handlerToken)
+        }
     }
     
-    internal func addCompletionHandler(inout token: HandlerToken?, _ completionHandler: Void -> Void)
+    internal func addCompletionHandler(inout token: _HandlerToken?, _ completionHandler: Void -> Void)
     {
         if self.state == .Running || self.state == .Paused {
             token = self.completionHandlers.append(completionHandler)
         }
     }
     
-    internal func removeCompletionHandler(handlerToken: HandlerToken)
+    internal func removeCompletionHandler(handlerToken: _HandlerToken?)
     {
-        self.completionHandlers.remove(handlerToken)
+        if let handlerToken = handlerToken {
+            self.completionHandlers.remove(handlerToken)
+        }
     }
     
     internal func handleProgress(progress: Progress)
@@ -201,7 +205,7 @@ internal class _StateMachine<Progress, Value, Error>
 // MARK: - Utility
 //--------------------------------------------------
 
-public struct HandlerToken
+internal struct _HandlerToken
 {
     internal let key: Int
 }
@@ -211,16 +215,16 @@ internal struct _Handlers<T>: SequenceType
     private var currentKey: Int = 0
     private var elements = [Int : T]()
     
-    internal mutating func append(value: T) -> HandlerToken
+    internal mutating func append(value: T) -> _HandlerToken
     {
         self.currentKey = self.currentKey &+ 1
         
         self.elements[self.currentKey] = value
         
-        return HandlerToken(key: self.currentKey)
+        return _HandlerToken(key: self.currentKey)
     }
     
-    internal mutating func remove(token: HandlerToken)
+    internal mutating func remove(token: _HandlerToken)
     {
         self.elements.removeValueForKey(token.key)
     }

--- a/SwiftTaskTests/RemoveHandlerTests.swift
+++ b/SwiftTaskTests/RemoveHandlerTests.swift
@@ -1,0 +1,114 @@
+//
+//  RemoveHandlerTests.swift
+//  SwiftTask
+//
+//  Created by Yasuhiro Inami on 2015/05/28.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import SwiftTask
+import Async
+import XCTest
+
+class RemoveHandlerTests: _TestCase
+{
+    func testRemoveProgress()
+    {
+        typealias Task = SwiftTask.Task<Float, String, ErrorString>
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        var progressToken: HandlerToken? = nil
+        
+        // define task
+        let task = Task { progress, fulfill, reject, configure in
+            
+            progress(0.0)
+            
+            Async.main(after: 0.1) {
+                progress(1.0)
+                
+                fulfill("OK")
+            }
+            
+        }
+        
+        task.progress { oldProgress, newProgress in
+            
+            println("progress1 = \(newProgress)")
+        
+        }.progress(&progressToken) { oldProgress, newProgress in
+            
+            println("progress2 = \(newProgress)")
+            XCTFail("Should never reach here because this progress-handler will be removed soon.")
+            
+        }.then { value, errorInfo -> Void in
+            
+            XCTAssertTrue(value == "OK")
+            XCTAssertTrue(errorInfo == nil)
+            expect.fulfill()
+                
+        }
+        
+        XCTAssertTrue(progressToken != nil, "Async `task` will return non-nil `progressToken`.")
+        
+        // remove progress-handler
+        task.removeProgress(progressToken!)
+        
+        self.wait()
+    }
+    
+    func testRemoveThen()
+    {
+        typealias Task = SwiftTask.Task<Float, String, ErrorString>
+        
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        var progressCount = 0
+        
+        // define task
+        let task = Task { progress, fulfill, reject, configure in
+            
+            progress(0.0)
+            
+            Async.main(after: 0.1) {
+                progress(1.0)
+                fulfill("OK")
+            }
+            
+        }
+        
+        var thenToken: HandlerToken? = nil
+        
+        // NOTE: reference to `task2` is required in order to call `task2.removeThen(thenToken)`
+        let task2 = task.success { value -> String in
+                
+            XCTAssertEqual(value, "OK")
+            return "Now OK"
+                
+        }
+        
+        task2.then(&thenToken) { value, errorInfo -> String in
+            
+            println("Should never reach here")
+            
+            XCTFail("Should never reach here because this then-handler will be removed soon.")
+            
+            return "Never reaches here"
+            
+        }.then { value, errorInfo -> Void in
+            
+            XCTAssertTrue(value == nil)
+            XCTAssertTrue(errorInfo != nil)
+            XCTAssertTrue(errorInfo!.error == nil)
+            XCTAssertTrue(errorInfo!.isCancelled, "`task2.removeThen(token)` will force `let task3 = task2.then(&token)` to deinit immediately and tries cancellation if it is still running.")
+            
+            expect.fulfill()
+                
+        }
+        
+        // remove then-handler
+        task2.removeThen(thenToken!)
+        
+        self.wait()
+    }
+}

--- a/SwiftTaskTests/RemoveHandlerTests.swift
+++ b/SwiftTaskTests/RemoveHandlerTests.swift
@@ -18,26 +18,22 @@ class RemoveHandlerTests: _TestCase
         
         var expect = self.expectationWithDescription(__FUNCTION__)
         
-        var progressToken: HandlerToken? = nil
+        var latestProgressValue: Float?
+        var canceller: AutoCanceller? = nil
         
         // define task
-        let task = Task { progress, fulfill, reject, configure in
-            
+        Task { progress, fulfill, reject, configure in
             progress(0.0)
-            
             Async.main(after: 0.1) {
                 progress(1.0)
-                
                 fulfill("OK")
             }
-            
-        }
-        
-        task.progress { oldProgress, newProgress in
+        }.progress { oldProgress, newProgress in
             
             println("progress1 = \(newProgress)")
+            latestProgressValue = newProgress
         
-        }.progress(&progressToken) { oldProgress, newProgress in
+        }.progress(&canceller) { oldProgress, newProgress in
             
             println("progress2 = \(newProgress)")
             XCTFail("Should never reach here because this progress-handler will be removed soon.")
@@ -50,44 +46,37 @@ class RemoveHandlerTests: _TestCase
                 
         }
         
-        XCTAssertTrue(progressToken != nil, "Async `task` will return non-nil `progressToken`.")
+        XCTAssertTrue(canceller != nil, "Async `task` will return non-nil `progressToken`.")
         
         // remove progress-handler
-        task.removeProgress(progressToken!)
+        canceller = nil
         
         self.wait()
+        
+        XCTAssertTrue(latestProgressValue == 1.0)
     }
     
     func testRemoveThen()
     {
         typealias Task = SwiftTask.Task<Float, String, ErrorString>
-        
+
         var expect = self.expectationWithDescription(__FUNCTION__)
-        var progressCount = 0
+        var canceller: AutoCanceller? = nil
         
         // define task
-        let task = Task { progress, fulfill, reject, configure in
-            
-            progress(0.0)
+        Task { progress, fulfill, reject, configure in
             
             Async.main(after: 0.1) {
-                progress(1.0)
                 fulfill("OK")
             }
+            return
             
-        }
-        
-        var thenToken: HandlerToken? = nil
-        
-        // NOTE: reference to `task2` is required in order to call `task2.removeThen(thenToken)`
-        let task2 = task.success { value -> String in
+        }.success { value -> String in
                 
             XCTAssertEqual(value, "OK")
             return "Now OK"
-                
-        }
         
-        task2.then(&thenToken) { value, errorInfo -> String in
+        }.then(&canceller) { value, errorInfo -> String in
             
             println("Should never reach here")
             
@@ -97,17 +86,20 @@ class RemoveHandlerTests: _TestCase
             
         }.then { value, errorInfo -> Void in
             
+            println("value = \(value)")
+            println("errorInfo = \(errorInfo)")
+            
             XCTAssertTrue(value == nil)
             XCTAssertTrue(errorInfo != nil)
             XCTAssertTrue(errorInfo!.error == nil)
-            XCTAssertTrue(errorInfo!.isCancelled, "`task2.removeThen(token)` will force `let task3 = task2.then(&token)` to deinit immediately and tries cancellation if it is still running.")
+            XCTAssertTrue(errorInfo!.isCancelled, "Deallocation of `canceller` will force `task2` (where `task2 = task.then(&canceller)`) to deinit immediately and tries cancellation if it is still running.")
             
             expect.fulfill()
                 
         }
         
         // remove then-handler
-        task2.removeThen(thenToken!)
+        canceller = nil
         
         self.wait()
     }

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -598,7 +598,7 @@ class SwiftTaskTests: _TestCase
         // cancel at time between 1st & 2nd delay (t=0.3)
         Async.main(after: 0.3) {
             
-            task.cancel(error: "I get bored.")
+            task.cancel("I get bored.")
             
             XCTAssertEqual(task.state, TaskState.Cancelled)
             
@@ -635,7 +635,7 @@ class SwiftTaskTests: _TestCase
         // cancel task3 at time between task1 fulfilled & before task2 completed (t=0.6)
         Async.main(after: 0.6) {
             
-            task3.cancel(error: "I get bored.")
+            task3.cancel("I get bored.")
             
             XCTAssertEqual(task3.state, TaskState.Cancelled)
             
@@ -1175,7 +1175,7 @@ class SwiftTaskTests: _TestCase
         
         // cancel before fulfilled
         Async.main(after: 0.01) {
-            groupedTask.cancel(error: "Cancel")
+            groupedTask.cancel("Cancel")
             return
         }
         
@@ -1390,7 +1390,7 @@ class SwiftTaskTests: _TestCase
         
         // cancel before fulfilled
         self.perform {
-            groupedTask.cancel(error: "Cancel")
+            groupedTask.cancel("Cancel")
             return
         }
         

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -598,7 +598,7 @@ class SwiftTaskTests: _TestCase
         // cancel at time between 1st & 2nd delay (t=0.3)
         Async.main(after: 0.3) {
             
-            task.cancel("I get bored.")
+            task.cancel(error: "I get bored.")
             
             XCTAssertEqual(task.state, TaskState.Cancelled)
             
@@ -635,7 +635,7 @@ class SwiftTaskTests: _TestCase
         // cancel task3 at time between task1 fulfilled & before task2 completed (t=0.6)
         Async.main(after: 0.6) {
             
-            task3.cancel("I get bored.")
+            task3.cancel(error: "I get bored.")
             
             XCTAssertEqual(task3.state, TaskState.Cancelled)
             
@@ -1175,7 +1175,7 @@ class SwiftTaskTests: _TestCase
         
         // cancel before fulfilled
         Async.main(after: 0.01) {
-            groupedTask.cancel("Cancel")
+            groupedTask.cancel(error: "Cancel")
             return
         }
         
@@ -1390,7 +1390,7 @@ class SwiftTaskTests: _TestCase
         
         // cancel before fulfilled
         self.perform {
-            groupedTask.cancel("Cancel")
+            groupedTask.cancel(error: "Cancel")
             return
         }
         


### PR DESCRIPTION
(JavaScript) Promise is normally designed to only *attach* `then`-handlers to preceding task, but it often lacks in those *removability*, especially when user wants to remove them *one-by-one*. 
(Promise usually `removeAll()` when it is deallocated)

This kind of casual & rough monad structure is not an issue when only dealing with a single future value, but when multiple progressing values come in, without a support of *one-by-one* invalidation, it will degrade efficiency of multiple task collaboration, i.e. ReactKit.

This pull request will add **one-by-one invalidation of `progress`/`then` handlers** by using `Canceller`.
Unlike publish-subscribe-model which normally returns disposable token as returning value,
I decided to use `inout` parameter to maintain Promise pipelining.

### Usage

```
let task = ...
var canceller: Canceller? = nil

task.progress(&canceller) { ... }.then { ... }

// at some point before `task` completes
canceller?.cancel()   // removes progressHandler
```