### PR TITLE
Change behavior of 1st-resume.

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -34,7 +34,7 @@ public class TaskConfiguration
     /// useful to terminate immediate-infinite-sequence while performing `initClosure`
     public var isFinished : Bool
     {
-        return _isFinished.rawValue
+        return self._isFinished.rawValue
     }
     
     private var _isFinished = _Atomic(false)
@@ -220,7 +220,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
         self._initClosure = _initClosure
         
         // will be invoked on 1st resume (only once)
-        self._machine.initResumeClosure = { [weak self] in
+        self._machine.initResumeClosure.rawValue = { [weak self] in
             
             // strongify `self` on 1st resume
             if let self_ = self {

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -32,12 +32,12 @@ public class TaskConfiguration
     public var cancel: (Void -> Void)?
     
     /// useful to terminate immediate-infinite-sequence while performing `initClosure`
-    public private(set) var isFinished: Bool = false
-    
-    public init()
+    public var isFinished : Bool
     {
-        
+        return _isFinished.rawValue
     }
+    
+    private var _isFinished = _Atomic(false)
     
     internal func finish()
     {
@@ -53,7 +53,7 @@ public class TaskConfiguration
         self.pause = nil
         self.resume = nil
         self.cancel = nil
-        self.isFinished = true
+        self._isFinished.rawValue = true
     }
 }
 


### PR DESCRIPTION
Continuing https://github.com/ReactKit/SwiftTask/pull/33 (thread-safety).

This pull request will improve 1st-`handleResume()` (call of `initResumeClosure`) by not switching around internal states to force-call `configure.resume()` when task's initial state is `.Paused`.
(switching around can be dangerous when transitions e.g. `handleProgress()` occurs in other threads)

Also, force-calling `configure.resume()` after `initResumeClosure()` will be annoying especially in ReactKit when it wants to 1st-resume upstream in other threads (e.g. `startAsync` or `Rx.subscribeOn`), whereas `configure.resume()` will 1st-resume in current thread, so its timing will be indeterminate.

Thus, **from ver 3.2.0, `configure.resume()` will be called from 2nd time of `resume()`**, 
considering 1st time as *start* of the task. 
This change will not modify current API, but behavior may change slightly.

**NOTE** If you are using SwiftTask as standalone, this fix will not affect in most cases because its initial state is set as `.Running` by default.