### PR TITLE
Handling multiple error types.

### DIFF
--- a/SwiftTask.xcodeproj/project.pbxproj
+++ b/SwiftTask.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F20250119ADA8FD00DE0495 /* BasicTests.swift */; };
 		1F218D5B1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */; };
 		1F218D5C1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */; };
+		1F29F6421B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F29F6411B115EF500F476AF /* MultipleErrorTypesTests.swift */; };
+		1F29F6431B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F29F6411B115EF500F476AF /* MultipleErrorTypesTests.swift */; };
 		1F46DEDA199EDF1000F97868 /* SwiftTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F46DED9199EDF1000F97868 /* SwiftTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F46DEFB199EDF8100F97868 /* SwiftTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFA199EDF8100F97868 /* SwiftTask.swift */; };
 		1F46DEFD199EE2C200F97868 /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFC199EE2C200F97868 /* _TestCase.swift */; };
@@ -46,6 +48,7 @@
 /* Begin PBXFileReference section */
 		1F20250119ADA8FD00DE0495 /* BasicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTests.swift; sourceTree = "<group>"; };
 		1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoveHandlerTests.swift; sourceTree = "<group>"; };
+		1F29F6411B115EF500F476AF /* MultipleErrorTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleErrorTypesTests.swift; sourceTree = "<group>"; };
 		1F46DED4199EDF1000F97868 /* SwiftTask.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftTask.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F46DED8199EDF1000F97868 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F46DED9199EDF1000F97868 /* SwiftTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftTask.h; sourceTree = "<group>"; };
@@ -161,6 +164,7 @@
 				485C31F01A1D619A00040DA3 /* TypeInferenceTests.swift */,
 				1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */,
 				1F5FA35619A374E600975FB9 /* AlamofireTests.swift */,
+				1F29F6411B115EF500F476AF /* MultipleErrorTypesTests.swift */,
 				1F46DEE1199EDF1000F97868 /* Supporting Files */,
 			);
 			path = SwiftTaskTests;
@@ -366,6 +370,7 @@
 				1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
 				1F218D5B1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
 				1F6A8CA319A4E4F200369A5D /* SwiftTaskTests.swift in Sources */,
+				1F29F6421B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */,
 				1F4C76A41AD8CF40004E47C1 /* AlamofireTests.swift in Sources */,
 				485C31F11A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,
 				48511C5B19C17563002FE03C /* RetainCycleTests.swift in Sources */,
@@ -381,6 +386,7 @@
 				4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */,
 				1F218D5C1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
 				1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
+				1F29F6431B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */,
 				1F4C76A51AD8CF41004E47C1 /* AlamofireTests.swift in Sources */,
 				485C31F21A1D619A00040DA3 /* TypeInferenceTests.swift in Sources */,
 				4822F0DC19D00B2300F5F572 /* _TestCase.swift in Sources */,

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -521,15 +521,15 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     /// - e.g. task.failure { errorInfo -> NextTaskType in ... }
     /// - e.g. task.failure { error, isCancelled -> NextTaskType in ... }
     ///
-    public func failure<Progress2>(failureClosure: ErrorInfo -> Task<Progress2, Value, Error>) -> Task<Progress2, Value, Error>
+    public func failure<Progress2, Error2>(failureClosure: ErrorInfo -> Task<Progress2, Value, Error2>) -> Task<Progress2, Value, Error2>
     {
         var dummyCanceller: Canceller? = nil
         return self.failure(&dummyCanceller, failureClosure)
     }
     
-    public func failure<Progress2, C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Task<Progress2, Value, Error>) -> Task<Progress2, Value, Error>
+    public func failure<Progress2, Error2, C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Task<Progress2, Value, Error2>) -> Task<Progress2, Value, Error2>
     {
-        return Task<Progress2, Value, Error> { [unowned self] newMachine, progress, fulfill, _reject, configure in
+        return Task<Progress2, Value, Error2> { [unowned self] newMachine, progress, fulfill, _reject, configure in
             
             let selfMachine = self._machine
             

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -398,7 +398,7 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     ///
     /// - e.g. task.then { value, errorInfo -> NextTaskType in ... }
     ///
-    public func then<Progress2, Value2>(thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error>) -> Task<Progress2, Value2, Error>
+    public func then<Progress2, Value2, Error2>(thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error2>) -> Task<Progress2, Value2, Error2>
     {
         var dummyCanceller: Canceller? = nil
         return self.then(&dummyCanceller, thenClosure)
@@ -410,9 +410,9 @@ public class Task<Progress, Value, Error>: Cancellable, Printable
     // - `let canceller = Canceller(); task1.then(&canceller) {...}; canceller.cancel();`
     // - `let task2 = task1.then {...}; task2.cancel();`
     //
-    public func then<Progress2, Value2, C: Canceller>(inout canceller: C?, _ thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error>) -> Task<Progress2, Value2, Error>
+    public func then<Progress2, Value2, Error2, C: Canceller>(inout canceller: C?, _ thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error2>) -> Task<Progress2, Value2, Error2>
     {
-        return Task<Progress2, Value2, Error> { [unowned self, weak canceller] newMachine, progress, fulfill, _reject, configure in
+        return Task<Progress2, Value2, Error2> { [unowned self, weak canceller] newMachine, progress, fulfill, _reject, configure in
             
             //
             // NOTE: 

--- a/SwiftTaskTests/MultipleErrorTypesTests.swift
+++ b/SwiftTaskTests/MultipleErrorTypesTests.swift
@@ -1,0 +1,86 @@
+//
+//  MultipleErrorTypesTests.swift
+//  SwiftTask
+//
+//  Created by Yasuhiro Inami on 2015/05/24.
+//  Copyright (c) 2015年 Yasuhiro Inami. All rights reserved.
+//
+
+import SwiftTask
+import Async
+import XCTest
+
+class MultipleErrorTypesTests: _TestCase
+{
+    enum MyEnum
+    {
+        case Default
+    }
+    
+    struct Dummy {}
+    
+    typealias Task1 = Task<String, String, String>
+    typealias Task2 = Task<MyEnum, MyEnum, MyEnum>
+    
+    var flow = [Int]()
+    
+    // delayed task + counting flow 1 & 2
+    func _task1(#success: Bool) -> Task1
+    {
+        return Task1 { progress, fulfill, reject, configure in
+            println("[task1] start")
+            self.flow += [1]
+            
+            Async.main(after: 0.1) {
+                println("[task1] end")
+                self.flow += [2]
+                
+                success ? fulfill("OK") : reject("NG")
+            }
+            return
+        }
+    }
+    
+    // delayed task + counting flow 4 & 5
+    func _task2(#success: Bool) -> Task2
+    {
+        return Task2 { progress, fulfill, reject, configure in
+            println("[task2] start")
+            self.flow += [4]
+            
+            Async.main(after: 0.1) {
+                println("[task2] end")
+                self.flow += [5]
+                
+                success ? fulfill(.Default) : reject(.Default)
+            }
+            return
+        }
+    }
+    
+    func testMultipleErrorTypes_then()
+    {
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        self._task1(success: true)
+            .then { value, errorInfo -> Task2 in
+                
+                println("task1.then")
+                self.flow += [3]
+                
+                return self._task2(success: true)
+                
+            }
+            .then { value, errorInfo -> Void in
+                
+                println("task1.then.then (task2 should end at this point)")
+                self.flow += [6]
+                
+                XCTAssertEqual(self.flow, Array(1...6), "Tasks should flow in order from 1 to 6.")
+                expect.fulfill()
+                
+            }
+        
+        self.wait()
+    }
+}

--- a/SwiftTaskTests/MultipleErrorTypesTests.swift
+++ b/SwiftTaskTests/MultipleErrorTypesTests.swift
@@ -83,4 +83,31 @@ class MultipleErrorTypesTests: _TestCase
         
         self.wait()
     }
+    
+    func testMultipleErrorTypes_success()
+    {
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        self._task1(success: true)
+            .success { value -> Task2 in
+                
+                println("task1.success")
+                self.flow += [3]
+                
+                return self._task2(success: true)
+                
+            }
+            .success { value -> Void in
+                
+                println("task1.success.success (task2 should end at this point)")
+                self.flow += [6]
+                
+                XCTAssertEqual(self.flow, Array(1...6), "Tasks should flow in order from 1 to 6.")
+                expect.fulfill()
+                
+            }
+        
+        self.wait()
+    }
+    
 }

--- a/SwiftTaskTests/MultipleErrorTypesTests.swift
+++ b/SwiftTaskTests/MultipleErrorTypesTests.swift
@@ -12,9 +12,10 @@ import XCTest
 
 class MultipleErrorTypesTests: _TestCase
 {
-    enum MyEnum
+    enum MyEnum: Printable
     {
         case Default
+        var description: String { return "MyEnumDefault" }
     }
     
     struct Dummy {}
@@ -25,7 +26,7 @@ class MultipleErrorTypesTests: _TestCase
     var flow = [Int]()
     
     // delayed task + counting flow 1 & 2
-    func _task1(#success: Bool) -> Task1
+    func _task1(#ok: Bool) -> Task1
     {
         return Task1 { progress, fulfill, reject, configure in
             println("[task1] start")
@@ -35,14 +36,14 @@ class MultipleErrorTypesTests: _TestCase
                 println("[task1] end")
                 self.flow += [2]
                 
-                success ? fulfill("OK") : reject("NG")
+                ok ? fulfill("OK") : reject("NG")
             }
             return
         }
     }
     
     // delayed task + counting flow 4 & 5
-    func _task2(#success: Bool) -> Task2
+    func _task2(#ok: Bool) -> Task2
     {
         return Task2 { progress, fulfill, reject, configure in
             println("[task2] start")
@@ -52,7 +53,7 @@ class MultipleErrorTypesTests: _TestCase
                 println("[task2] end")
                 self.flow += [5]
                 
-                success ? fulfill(.Default) : reject(.Default)
+                ok ? fulfill(.Default) : reject(.Default)
             }
             return
         }
@@ -62,13 +63,13 @@ class MultipleErrorTypesTests: _TestCase
     {
         var expect = self.expectationWithDescription(__FUNCTION__)
         
-        self._task1(success: true)
+        self._task1(ok: true)
             .then { value, errorInfo -> Task2 in
                 
                 println("task1.then")
                 self.flow += [3]
                 
-                return self._task2(success: true)
+                return self._task2(ok: true)
                 
             }
             .then { value, errorInfo -> Void in
@@ -88,13 +89,13 @@ class MultipleErrorTypesTests: _TestCase
     {
         var expect = self.expectationWithDescription(__FUNCTION__)
         
-        self._task1(success: true)
+        self._task1(ok: true)
             .success { value -> Task2 in
                 
                 println("task1.success")
                 self.flow += [3]
                 
-                return self._task2(success: true)
+                return self._task2(ok: true)
                 
             }
             .success { value -> Void in
@@ -110,11 +111,89 @@ class MultipleErrorTypesTests: _TestCase
         self.wait()
     }
 
+    func testMultipleErrorTypes_success_differentErrorType()
+    {
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        self._task1(ok: true)
+            .success { value -> Task2 in
+                
+                println("task1.success")
+                self.flow += [3]
+                
+                //
+                // NOTE: 
+                // If Task1 and Task2 have different Error types,
+                // returning `self._task2(ok: false)` inside `self._task1.success()` will fail error conversion 
+                // (Task2.Error -> Task1.Error).
+                //
+                return self._task2(ok: false) // inner rejection with different Error type
+                
+            }
+            .then { value, errorInfo -> Void in
+                
+                println("task1.success.success (task2 should end at this point)")
+                self.flow += [6]
+                
+                XCTAssertEqual(self.flow, Array(1...6), "Tasks should flow in order from 1 to 6.")
+                
+                XCTAssertTrue(value == nil)
+                XCTAssertTrue(errorInfo != nil)
+                XCTAssertTrue(errorInfo!.error == nil, "Though `errorInfo` will still be non-nil, `errorInfo!.error` will become as `nil` if Task1 and Task2 have different Error types.")
+                XCTAssertTrue(errorInfo!.isCancelled == false)
+                
+                expect.fulfill()
+                
+            }
+        
+        self.wait()
+    }
+    
+    func testMultipleErrorTypes_success_differentErrorType_conversion()
+    {
+        var expect = self.expectationWithDescription(__FUNCTION__)
+        
+        self._task1(ok: true)
+            .success { value -> Task<Void, MyEnum, String> in
+                
+                println("task1.success")
+                self.flow += [3]
+                
+                //
+                // NOTE:
+                // Since returning `self._task2(ok: false)` inside `self._task1.success()` will fail error conversion
+                // (Task2.Error -> Task1.Error) as seen in above test case,
+                // it is **user's responsibility** to add conversion logic to maintain same Error type throughout task-flow.
+                //
+                return self._task2(ok: false)
+                    .failure { Task<Void, MyEnum, String>(error: "Mapping errorInfo=\($0.error!) to String") }  // error-conversion
+                
+            }
+            .then { value, errorInfo -> Void in
+                
+                println("task1.success.success (task2 should end at this point)")
+                self.flow += [6]
+                
+                XCTAssertEqual(self.flow, Array(1...6), "Tasks should flow in order from 1 to 6.")
+                
+                XCTAssertTrue(value == nil)
+                XCTAssertTrue(errorInfo != nil)
+                XCTAssertEqual(errorInfo!.error!, "Mapping errorInfo=MyEnumDefault to String",
+                    "Now `self._task2()`'s error is catched by this scope by adding manual error-conversion logic by user side.")
+                XCTAssertTrue(errorInfo!.isCancelled == false)
+                
+                expect.fulfill()
+                
+        }
+        
+        self.wait()
+    }
+
     func testMultipleErrorTypes_failure()
     {
         var expect = self.expectationWithDescription(__FUNCTION__)
         
-        self._task1(success: false)
+        self._task1(ok: false)
             .failure { errorInfo -> Task<Dummy, String /* must be task1's value type to recover */, Dummy> in
                 
                 println("task1.failure")
@@ -125,7 +204,7 @@ class MultipleErrorTypesTests: _TestCase
                 // Returning `Task2` won't work since same Value type as `task1` is required inside `task1.failure()`,
                 // so use `then()` to promote `Task2` to `Task<..., Task1.Value, ...>`.
                 //
-                return self._task2(success: false).then { value, errorInfo in
+                return self._task2(ok: false).then { value, errorInfo in
                     return Task<Dummy, String, Dummy>(error: Dummy())  // error task
                 }
             }


### PR DESCRIPTION
This pull request will fix https://github.com/ReactKit/SwiftTask/issues/37 by:

- [x] improving type-inference for overloaded `then()`/`success()`/`failure()` to not use the wrong one
- [x] using `then()` to promote Task type from `Task<P1, V1, E1>` to `Task<P2, V2, E2>` (including `E1 -> E2` Error type change)

For more information, please see [MultipleErrorTypesTests.swift#L61-L144](https://github.com/ReactKit/SwiftTask/blob/dd698b9c5e4dc581c6b07e892b0bfdb563a809f3/SwiftTaskTests/MultipleErrorTypesTests.swift#L61-L144).

### Caveat

```
let task1: Task1 = self.request1()
task1.success { _ -> Task2 in
    return self.request2() // let's say, this task will fail
}.then { value, errorInfo -> Void in
    // NOTE:
    // Though `errorInfo` will still be non-nil, `errorInfo!.error` will become as `nil`
    // if Task1 and Task2 have different Error types.
}
```

If Task1 and Task2 have different Error types and `request2` fails, 
you will still receive `errorInfo` as non-nil, but now **`errorInfo!.error` will become as `nil`**.

- [MultipleErrorTypesTests.swift#L114-L150](https://github.com/ReactKit/SwiftTask/blob/fac9ff68ef2caf8027ddf1c68e4acbf6d7e2d25a/SwiftTaskTests/MultipleErrorTypesTests.swift#L114-L150)

This is because there is no way to convert `request2`'s error back to task1's Error type (which is required in task-flow).

To avoid this default behavior, it is user's job to add error-conversion logic to maintain same Error type throughout the task-flow, by adding another type-promotable `then()`/`success()`/`failure()`. 

- [MultipleErrorTypesTests.swift#L152-L190](https://github.com/ReactKit/SwiftTask/blob/fac9ff68ef2caf8027ddf1c68e4acbf6d7e2d25a/SwiftTaskTests/MultipleErrorTypesTests.swift#L152-L190)