### PR TITLE
add .success / .failure methods that cause sideeffects only

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -198,6 +198,20 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         })
     }
     
+    ///
+    /// creates rejected task with ErrorInfo
+    ///
+    /// - e.g. Task<P, V, E>(errorInfo: someErrorInfo)
+    ///
+    internal convenience init(errorInfo: ErrorInfo)
+    {
+        self.init(_initClosure: { machine, progress, fulfill, _reject, configure in
+            _reject(errorInfo)
+        })
+        
+        self.name = "RejectedTask"
+    }
+    
     /// internal-init for accessing `machine` inside `_initClosure`
     /// (NOTE: _initClosure has _RejectInfoHandler as argument)
     internal init(weakified: Bool = false, paused: Bool = false, _initClosure: _InitClosure)
@@ -448,6 +462,25 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
+    /// success (fulfilled) + closure returning nothing
+    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    ///
+    /// - e.g. task.success { value -> Void in ... }
+    ///
+    public func success(successClosure: Value -> Void) -> Task
+    {
+        var dummyCanceller: Canceller? = nil
+        return self.success(&dummyCanceller, successClosure)
+    }
+    
+    public func success<C: Canceller>(inout canceller: C?, _ successClosure: Value -> Void) -> Task
+    {
+        return self.success(&canceller) { (value: Value) -> Task in
+            return Task(value: value)
+        }
+    }
+    
+    ///
     /// success (fulfilled) + closure returning **value**
     ///
     /// - e.g. task.success { value -> NextValueType in ... }
@@ -496,6 +529,27 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         }.name("\(self.name)-success")
     }
     
+    ///
+    /// failure (rejected or cancelled) + closure returning nothing
+    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    ///
+    /// - e.g. task.failure { errorInfo -> Void in ... }
+    /// - e.g. task.failure { error, isCancelled -> Void in ... }
+    ///
+    
+    public func failure(failureClosure: ErrorInfo -> Void) -> Task
+    {
+        var dummyCanceller: Canceller? = nil
+        return self.failure(&dummyCanceller, failureClosure)
+    }
+    
+    public func failure<C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Void) -> Task
+    {
+        return self.failure(&canceller) { (errorInfo: ErrorInfo) -> Task in
+            return Task(errorInfo: errorInfo)
+        }
+    }
+
     ///
     /// failure (rejected or cancelled) + closure returning **value**
     ///

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -463,7 +463,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     
     ///
     /// success (fulfilled) + closure returning nothing
-    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    /// used as transparent (i.e. it doesn't affect passed Task) handler.
     ///
     /// - e.g. task.success { value -> Void in ... }
     ///
@@ -476,6 +476,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     public func success<C: Canceller>(inout canceller: C?, _ successClosure: Value -> Void) -> Task
     {
         return self.success(&canceller) { (value: Value) -> Task in
+            successClosure(value)
             return Task(value: value)
         }
     }
@@ -531,7 +532,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     
     ///
     /// failure (rejected or cancelled) + closure returning nothing
-    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    /// used as transparent (i.e. it doesn't affect passed Task) handler.
     ///
     /// - e.g. task.failure { errorInfo -> Void in ... }
     /// - e.g. task.failure { error, isCancelled -> Void in ... }
@@ -546,6 +547,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     public func failure<C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Void) -> Task
     {
         return self.failure(&canceller) { (errorInfo: ErrorInfo) -> Task in
+            failureClosure(errorInfo)
             return Task(errorInfo: errorInfo)
         }
     }


### PR DESCRIPTION
It will be handy if we could just add event handlers without changing values or types of Tasks
(now SwiftTask requires .success / .failure closures to return a new value or Task).
In particular, it's painful to use .failure when you just want to add an event handler and don't want to recover from failures, because it still requires successful return value.

This PR adds .success / .failure methods which have closures of returning type Void for their arguments.
You pass a closure returns nothing (or Void), and you get a new Task nearly identical to previous one but it keeps the closure as an event handler.

This change disables handling Tasks with Void as the Value type (eg. Task<Progress, Void, Error>), but no one might want to use such creepy Tasks :wink:
