### PR TITLE
Add `on(success:failure:)` for adding side-effects.

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -548,10 +548,15 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     
     public func on(success success: Value -> Void = { _ in }, failure: ErrorInfo -> Void = { _ in }) -> Self
     {
+        var dummyCanceller: Canceller? = nil
+        return self.on(&dummyCanceller, success: success, failure: failure)
+    }
+    
+    public func on<C: Canceller>(inout canceller: C?, success: Value -> Void = { _ in }, failure: ErrorInfo -> Void = { _ in }) -> Self
+    {
         let selfMachine = self._machine
         
-        var dummyCanceller: Canceller? = nil
-        self._then(&dummyCanceller) {
+        self._then(&canceller) {
             if let value = selfMachine.value.rawValue {
                 success(value)
             }

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -198,6 +198,20 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         })
     }
     
+    ///
+    /// creates rejected task with ErrorInfo
+    ///
+    /// - e.g. Task<P, V, E>(errorInfo: someErrorInfo)
+    ///
+    internal convenience init(errorInfo: ErrorInfo)
+    {
+        self.init(_initClosure: { machine, progress, fulfill, _reject, configure in
+            _reject(errorInfo)
+        })
+        
+        self.name = "RejectedTask"
+    }
+    
     /// internal-init for accessing `machine` inside `_initClosure`
     /// (NOTE: _initClosure has _RejectInfoHandler as argument)
     internal init(weakified: Bool = false, paused: Bool = false, _initClosure: _InitClosure)
@@ -448,6 +462,25 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
+    /// success (fulfilled) + closure returning nothing
+    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    ///
+    /// - e.g. task.success { value -> Void in ... }
+    ///
+    public func success(successClosure: Value -> Void) -> Task
+    {
+        var dummyCanceller: Canceller? = nil
+        return self.success(&dummyCanceller, successClosure)
+    }
+    
+    public func success<C: Canceller>(inout canceller: C?, _ successClosure: Value -> Void) -> Task
+    {
+        return self.success(&canceller) { (value: Value) -> Task in
+            return Task(value: value)
+        }
+    }
+    
+    ///
     /// success (fulfilled) + closure returning **value**
     ///
     /// - e.g. task.success { value -> NextValueType in ... }
@@ -496,6 +529,27 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         }.name("\(self.name)-success")
     }
     
+    ///
+    /// failure (rejected or cancelled) + closure returning nothing
+    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    ///
+    /// - e.g. task.failure { errorInfo -> Void in ... }
+    /// - e.g. task.failure { error, isCancelled -> Void in ... }
+    ///
+    
+    public func failure(failureClosure: ErrorInfo -> Void) -> Task
+    {
+        var dummyCanceller: Canceller? = nil
+        return self.failure(&dummyCanceller, failureClosure)
+    }
+    
+    public func failure<C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Void) -> Task
+    {
+        return self.failure(&canceller) { (errorInfo: ErrorInfo) -> Task in
+            return Task(errorInfo: errorInfo)
+        }
+    }
+
     ///
     /// failure (rejected or cancelled) + closure returning **value**
     ///

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -463,7 +463,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     
     ///
     /// success (fulfilled) + closure returning nothing
-    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    /// used as transparent (i.e. it doesn't affect passed Task) handler.
     ///
     /// - e.g. task.success { value -> Void in ... }
     ///
@@ -476,6 +476,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     public func success<C: Canceller>(inout canceller: C?, _ successClosure: Value -> Void) -> Task
     {
         return self.success(&canceller) { (value: Value) -> Task in
+            successClosure(value)
             return Task(value: value)
         }
     }
@@ -531,7 +532,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     
     ///
     /// failure (rejected or cancelled) + closure returning nothing
-    /// used as transpalent (i.e. it doesn't affect passed Task) handler.
+    /// used as transparent (i.e. it doesn't affect passed Task) handler.
     ///
     /// - e.g. task.failure { errorInfo -> Void in ... }
     /// - e.g. task.failure { error, isCancelled -> Void in ... }
@@ -546,6 +547,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     public func failure<C: Canceller>(inout canceller: C?, _ failureClosure: ErrorInfo -> Void) -> Task
     {
         return self.failure(&canceller) { (errorInfo: ErrorInfo) -> Task in
+            failureClosure(errorInfo)
             return Task(errorInfo: errorInfo)
         }
     }

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -114,17 +114,17 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// Creates a new task.
+    /// Create a new task.
     ///
     /// - e.g. Task<P, V, E>(weakified: false, paused: false) { progress, fulfill, reject, configure in ... }
     ///
-    /// - parameter weakified: Weakifies progress/fulfill/reject handlers to let player (inner asynchronous implementation inside `initClosure`) NOT CAPTURE this created new task. Normally, `weakified = false` should be set to gain "player -> task" retaining, so that task will be automatically deinited when player is deinited. If `weakified = true`, task must be manually retained somewhere else, or it will be immediately deinited.
+    /// - Parameter weakified: Weakifies progress/fulfill/reject handlers to let player (inner asynchronous implementation inside `initClosure`) NOT CAPTURE this created new task. Normally, `weakified = false` should be set to gain "player -> task" retaining, so that task will be automatically deinited when player is deinited. If `weakified = true`, task must be manually retained somewhere else, or it will be immediately deinited.
     ///
-    /// - parameter paused: Flag to invoke `initClosure` immediately or not. If `paused = true`, task's initial state will be `.Paused` and needs to `resume()` in order to start `.Running`. If `paused = false`, `initClosure` will be invoked immediately.
+    /// - Parameter paused: Flag to invoke `initClosure` immediately or not. If `paused = true`, task's initial state will be `.Paused` and needs to `resume()` in order to start `.Running`. If `paused = false`, `initClosure` will be invoked immediately.
     ///
-    /// - parameter initClosure: e.g. { progress, fulfill, reject, configure in ... }. `fulfill(value)` and `reject(error)` handlers must be called inside this closure, where calling `progress(progressValue)` handler is optional. Also as options, `configure.pause`/`configure.resume`/`configure.cancel` closures can be set to gain control from outside e.g. `task.pause()`/`task.resume()`/`task.cancel()`. When using `configure`, make sure to use weak modifier when appropriate to avoid "task -> player" retaining which often causes retain cycle.
+    /// - Parameter initClosure: e.g. { progress, fulfill, reject, configure in ... }. `fulfill(value)` and `reject(error)` handlers must be called inside this closure, where calling `progress(progressValue)` handler is optional. Also as options, `configure.pause`/`configure.resume`/`configure.cancel` closures can be set to gain control from outside e.g. `task.pause()`/`task.resume()`/`task.cancel()`. When using `configure`, make sure to use weak modifier when appropriate to avoid "task -> player" retaining which often causes retain cycle.
     ///
-    /// - returns: New task.
+    /// - Returns: New task.
     ///
     public init(weakified: Bool, paused: Bool, initClosure: InitClosure)
     {
@@ -141,7 +141,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// creates a new task without weakifying progress/fulfill/reject handlers
+    /// Create a new task without weakifying progress/fulfill/reject handlers
     ///
     /// - e.g. Task<P, V, E>(paused: false) { progress, fulfill, reject, configure in ... }
     ///
@@ -151,7 +151,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// creates a new task without weakifying progress/fulfill/reject handlers (non-paused)
+    /// Create a new task without weakifying progress/fulfill/reject handlers (non-paused)
     ///
     /// - e.g. Task<P, V, E> { progress, fulfill, reject, configure in ... }
     ///
@@ -161,7 +161,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// creates fulfilled task (non-paused)
+    /// Create fulfilled task (non-paused)
     ///
     /// - e.g. Task<P, V, E>(value: someValue)
     ///
@@ -174,7 +174,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// creates rejected task (non-paused)
+    /// Create rejected task (non-paused)
     ///
     /// - e.g. Task<P, V, E>(error: someError)
     ///
@@ -187,7 +187,7 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// creates promise-like task which only allows fulfill & reject (no progress & configure)
+    /// Create promise-like task which only allows fulfill & reject (no progress & configure)
     ///
     /// - e.g. Task<Any, Value, Error> { fulfill, reject in ... }
     ///
@@ -353,7 +353,8 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     ///
     /// - e.g. task.progress { oldProgress, newProgress in ... }
     ///
-    /// NOTE: `oldProgress` is always nil when `weakified = true`
+    /// - Note: `oldProgress` is always nil when `weakified = true`
+    /// - Returns: Self (same `Task`)
     ///
     public func progress(progressClosure: ProgressTuple -> Void) -> Self
     {
@@ -374,10 +375,12 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// then (fulfilled & rejected) + closure returning **value** 
-    /// (a.k.a. `map` in functional programming term)
+    /// `then` (fulfilled & rejected) + closure returning **value**.
+    /// (similar to `map` in functional programming)
     ///
     /// - e.g. task.then { value, errorInfo -> NextValueType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func then<Value2>(thenClosure: (Value?, ErrorInfo?) -> Value2) -> Task<Progress, Value2, Error>
     {
@@ -393,10 +396,12 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// then (fulfilled & rejected) + closure returning **task**
-    /// (a.k.a. `flatMap` in functional programming term)
+    /// `then` (fulfilled & rejected) + closure returning **task**.
+    /// (similar to `flatMap` in functional programming)
     ///
     /// - e.g. task.then { value, errorInfo -> NextTaskType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func then<Progress2, Value2, Error2>(thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error2>) -> Task<Progress2, Value2, Error2>
     {
@@ -410,6 +415,8 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     // - `let canceller = Canceller(); task1.then(&canceller) {...}; canceller.cancel();`
     // - `let task2 = task1.then {...}; task2.cancel();`
     //
+    /// - Returns: New `Task`
+    ///
     public func then<Progress2, Value2, Error2, C: Canceller>(inout canceller: C?, _ thenClosure: (Value?, ErrorInfo?) -> Task<Progress2, Value2, Error2>) -> Task<Progress2, Value2, Error2>
     {
         return Task<Progress2, Value2, Error2> { [unowned self, weak canceller] newMachine, progress, fulfill, _reject, configure in
@@ -448,9 +455,12 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// success (fulfilled) + closure returning **value**
+    /// `success` (fulfilled) + closure returning **value**.
+    /// (synonym for `map` in functional programming)
     ///
     /// - e.g. task.success { value -> NextValueType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func success<Value2>(successClosure: Value -> Value2) -> Task<Progress, Value2, Error>
     {
@@ -466,9 +476,12 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// success (fulfilled) + closure returning **task**
+    /// `success` (fulfilled) + closure returning **task**
+    /// (synonym for `flatMap` in functional programming)
     ///
     /// - e.g. task.success { value -> NextTaskType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func success<Progress2, Value2, Error2>(successClosure: Value -> Task<Progress2, Value2, Error2>) -> Task<Progress2, Value2, Error>
     {
@@ -497,10 +510,13 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
     
     ///
-    /// failure (rejected or cancelled) + closure returning **value**
+    /// `failure` (rejected or cancelled) + closure returning **value**.
+    /// (synonym for `mapError` in functional programming)
     ///
     /// - e.g. task.failure { errorInfo -> NextValueType in ... }
     /// - e.g. task.failure { error, isCancelled -> NextValueType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func failure(failureClosure: ErrorInfo -> Value) -> Task
     {
@@ -516,10 +532,13 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     }
 
     ///
-    /// failure (rejected or cancelled) + closure returning **task**
+    /// `failure` (rejected or cancelled) + closure returning **task**.
+    /// (synonym for `flatMapError` in functional programming)
     ///
     /// - e.g. task.failure { errorInfo -> NextTaskType in ... }
     /// - e.g. task.failure { error, isCancelled -> NextTaskType in ... }
+    ///
+    /// - Returns: New `Task`
     ///
     public func failure<Progress2, Error2>(failureClosure: ErrorInfo -> Task<Progress2, Value, Error2>) -> Task<Progress2, Value, Error2>
     {
@@ -546,6 +565,12 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         }.name("\(self.name)-failure")
     }
     
+    ///
+    /// Add side-effects after completion.
+    ///
+    /// - Note: This method doesn't create new task, so it has better performance over `then()`/`success()`/`failure()`.
+    /// - Returns: Self (same `Task`)
+    ///
     public func on(success success: (Value -> Void)? = nil, failure: (ErrorInfo -> Void)? = nil) -> Self
     {
         var dummyCanceller: Canceller? = nil
@@ -568,11 +593,13 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         return self
     }
     
+    /// Pause task.
     public func pause() -> Bool
     {
         return self._machine.handlePause()
     }
     
+    /// Resume task.
     public func resume() -> Bool
     {
         return self._machine.handleResume()
@@ -584,11 +611,13 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
     // - `public func cancel(error: Error? = nil) -> Bool`
     // - `public func cancel(_ error: Error? = nil) -> Bool` (segfault in Swift 1.2)
     //
+    /// Cancel task.
     public func cancel() -> Bool
     {
         return self.cancel(error: nil)
     }
     
+    /// Cancel task.
     public func cancel(error error: Error?) -> Bool
     {
         return self._cancel(error)

--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -546,22 +546,22 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         }.name("\(self.name)-failure")
     }
     
-    public func on(success success: Value -> Void = { _ in }, failure: ErrorInfo -> Void = { _ in }) -> Self
+    public func on(success success: (Value -> Void)? = nil, failure: (ErrorInfo -> Void)? = nil) -> Self
     {
         var dummyCanceller: Canceller? = nil
         return self.on(&dummyCanceller, success: success, failure: failure)
     }
     
-    public func on<C: Canceller>(inout canceller: C?, success: Value -> Void = { _ in }, failure: ErrorInfo -> Void = { _ in }) -> Self
+    public func on<C: Canceller>(inout canceller: C?, success: (Value -> Void)? = nil, failure: (ErrorInfo -> Void)? = nil) -> Self
     {
         let selfMachine = self._machine
         
         self._then(&canceller) {
             if let value = selfMachine.value.rawValue {
-                success(value)
+                success?(value)
             }
             else if let errorInfo = selfMachine.errorInfo.rawValue {
-                failure(errorInfo)
+                failure?(errorInfo)
             }
         }
         

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -423,6 +423,57 @@ class SwiftTaskTests: _TestCase
     }
     
     //--------------------------------------------------
+    // MARK: - On
+    //--------------------------------------------------
+    
+    func testOn_success()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        Task<(), String, ErrorString> { progress, fulfill, reject, configure in
+            
+            self.perform {
+                fulfill("OK")
+            }
+            
+        }.on(success: { value in
+            
+            XCTAssertEqual(value, "OK")
+            expect.fulfill()
+            
+        }).on(failure: { error, isCancelled in
+            XCTFail("Should never reach here.")
+        })
+        
+        self.wait()
+    }
+    
+    func testOn_failure()
+    {
+        let expect = self.expectationWithDescription(__FUNCTION__)
+        
+        Task<(), String, ErrorString> { progress, fulfill, reject, configure in
+            
+            self.perform {
+                reject("NG")
+            }
+            
+            }.on(success: { value in
+                
+                XCTFail("Should never reach here.")
+                
+            }).on(failure: { error, isCancelled in
+                
+                XCTAssertEqual(error!, "NG")
+                XCTAssertFalse(isCancelled)
+                expect.fulfill()
+                
+            })
+        
+        self.wait()
+    }
+    
+    //--------------------------------------------------
     // MARK: - Progress
     //--------------------------------------------------
     

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.0"
+    version: "7.1"
 
 checkout:
   post:


### PR DESCRIPTION
This is a new feature and improvement on #50 to add side-effects after completion (success or failure) of task.

Please see [SwiftTaskTests.swift#L425-L474](https://github.com/ReactKit/SwiftTask/blob/c333c7daebaef504c4a797dfb82c5951f9545802/SwiftTaskTests/SwiftTaskTests.swift#L425-L474) for more detail.
### Note

Using `Self` for returning value will fail in Xcode 7.0, but not in 7.1.
