### PR TITLE
Implement when function

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -821,6 +821,56 @@ extension Task
         }.name("Task.some")
     }
     
+    private func toAnyTask() -> Task<Progress, AnyObject, Error>
+    {
+        return self.then{ (value, failureInfo) -> Task<Progress, AnyObject, Error> in
+            if let value = value as? AnyObject {
+                return Task<Progress, AnyObject ,Error>(value: value)
+            }
+            if let error = failureInfo?.error {
+                return Task<Progress, AnyObject, Error>(error: error)
+            }
+            fatalError()
+        }
+    }
+    
+    public class func when<Progress, Error, V, V2>(tasks: (Task<Progress, V, Error>, Task<Progress, V2, Error>)) -> Task<BulkProgress, (V, V2), Error>
+    {
+        return Task<BulkProgress, (V, V2), Error> { progress, fulfill, reject, _ in
+            Task<Progress, AnyObject, Error>.all([tasks.0.toAnyTask(), tasks.1.toAnyTask()]).success { values in
+                guard   let v1 = values[0] as? V,
+                    let v2 = values[1] as? V2 else {
+                        fatalError()
+                }
+                fulfill((v1, v2))
+                }.failure { error, _ in
+                    guard let error = error else { return }
+                    reject(error)
+                }.progress { (oldProgress, newProgress) -> Void in
+                    progress(newProgress)
+                }.name("Task.when")
+        }
+    }
+    
+    public class func when<Progress, Error, V, V2, V3>(tasks: (Task<Progress, V, Error>, Task<Progress, V2, Error>, Task<Progress, V3, Error>)) -> Task<BulkProgress, (V, V2, V3), Error>
+    {
+        return Task<BulkProgress, (V, V2, V3), Error> { progress, fulfill, reject, _ in
+            Task<Progress, AnyObject, Error>.all([tasks.0.toAnyTask(), tasks.1.toAnyTask(), tasks.2.toAnyTask()]).success { values in
+                guard   let v1 = values[0] as? V,
+                    let v2 = values[1] as? V2,
+                    let v3 = values[2] as? V3 else {
+                        fatalError()
+                }
+                fulfill((v1, v2, v3))
+                }.failure { error, _ in
+                    guard let error = error else { return }
+                    reject(error)
+                }.progress { (oldProgress, newProgress) -> Void in
+                    progress(newProgress)
+                }.name("Task.when")
+        }
+    }
+    
     public class func cancelAll(tasks: [Task])
     {
         for task in tasks {

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -1575,7 +1575,7 @@ class SwiftTaskTests: _TestCase
         let task2 = Task<Float, Int, NSError?> { fulfill, reject in fulfill(1) }
         let task3 = Task<Float, Double, NSError?> { fulfill, reject in fulfill(1.1) }
         
-        Task<Float, (String, Int), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
+        Task<Float, (String, Int, Double), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
             XCTAssertEqual(string, "Success")
             XCTAssertEqual(int, 1)
             XCTAssertEqual(double, 1.1)
@@ -1589,7 +1589,7 @@ class SwiftTaskTests: _TestCase
         let task2 = Task<Float, Int, String> { fulfill, reject in fulfill(1) }
         let task3 = Task<Float, Double, String> { fulfill, reject in  reject("Rejected") }
         
-        Task<Float, (String, Int), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
+        Task<Float, (String, Int, Double), String>.when((task1, task2, task3)).success { (string, int, double) -> Void in
             XCTFail()
             }.failure { (error, isCancelled) -> Void in
                 XCTAssertEqual(error, "Rejected")

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -1565,4 +1565,34 @@ class SwiftTaskTests: _TestCase
         
         self.wait()
     }
+    
+    //--------------------------------------------------
+    // MARK: - When
+    //--------------------------------------------------
+   
+    func testWhen_success() {
+        let task1 = Task<Float, String, NSError?> { fulfill, reject in fulfill("Success") }
+        let task2 = Task<Float, Int, NSError?> { fulfill, reject in fulfill(1) }
+        let task3 = Task<Float, Double, NSError?> { fulfill, reject in fulfill(1.1) }
+        
+        Task<Float, (String, Int), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
+            XCTAssertEqual(string, "Success")
+            XCTAssertEqual(int, 1)
+            XCTAssertEqual(double, 1.1)
+            }.failure { _ in
+                XCTFail()
+        }
+    }
+    
+    func testWhen_failure() {
+        let task1 = Task<Float, String, String> { fulfill, reject in fulfill("Success") }
+        let task2 = Task<Float, Int, String> { fulfill, reject in fulfill(1) }
+        let task3 = Task<Float, Double, String> { fulfill, reject in  reject("Rejected") }
+        
+        Task<Float, (String, Int), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
+            XCTFail()
+            }.failure { (error, isCancelled) -> Void in
+                XCTAssertEqual(error, "Rejected")
+        }
+    }
 }


### PR DESCRIPTION
I implement "when" method. 
It corresponds to multiple value type.
# Usage
- success pattern

``` swift
        let task1 = Task<Float, String, NSError?> { fulfill, reject in fulfill("Success") }
        let task2 = Task<Float, Int, NSError?> { fulfill, reject in fulfill(1) }
        let task3 = Task<Float, Double, NSError?> { fulfill, reject in fulfill(1.1) }

        Task<Float, (String, Int, Double), NSError>.when((task1, task2, task3)).success { (string, int, double) -> Void in
            print(string) // -> Success
            print(int) // -> 1
            print(double) // -> 1.1
        }.failure { (error, isCancelled) -> Void in
            fatalError()
        }
```

*failure pattern

``` swift
        let task1 = Task<Float, String, String> { fulfill, reject in fulfill("Success") }
        let task2 = Task<Float, Int, String> { fulfill, reject in fulfill(1) }
        let task3 = Task<Float, Double, String> { fulfill, reject in  reject("Rejected") }

        Task<Float, (String, Int, Double), String>.when((task1, task2, task3)).success { (string, int, double) -> Void in
            fatalError()
        }.failure { (error, isCancelled) -> Void in
            print(error) // -> Optional("Rejected")
        }
```
