### PR TITLE
Improve multiple task handling (`Task.all`/`any`/`some`) in case of empty `tasks`-argument

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -690,6 +690,10 @@ extension Task
     
     public class func all(tasks: [Task]) -> Task<BulkProgress, [Value], Error>
     {
+        guard !tasks.isEmpty else {
+            return Task<BulkProgress, [Value], Error>(value: [])
+        }
+
         return Task<BulkProgress, [Value], Error> { machine, progress, fulfill, _reject, configure in
             
             var completedCount = 0
@@ -737,6 +741,8 @@ extension Task
     
     public class func any(tasks: [Task]) -> Task
     {
+        precondition(!tasks.isEmpty, "`Task.any(tasks)` with empty `tasks` should not be called. It will never be fulfilled or rejected.")
+
         return Task<Progress, Value, Error> { machine, progress, fulfill, _reject, configure in
             
             var completedCount = 0
@@ -783,6 +789,10 @@ extension Task
     /// This new task will NEVER be internally rejected.
     public class func some(tasks: [Task]) -> Task<BulkProgress, [Value], Error>
     {
+        guard !tasks.isEmpty else {
+            return Task<BulkProgress, [Value], Error>(value: [])
+        }
+
         return Task<BulkProgress, [Value], Error> { machine, progress, fulfill, _reject, configure in
             
             var completedCount = 0


### PR DESCRIPTION
This is an improvement for multiple task handling (`Task.all`/`any`/`some`) to also work for empty `tasks` case as discussed in #59.

For compatibility, `Task.any` is using `precondition` instead to warn users not to pass empty array from the beginning.
(For better typing, we need different signature e.g. `public class func any(tasks: [Task]) -> Task<BulkProgress, Value?, Error>`)
