### PR TITLE
[Test] Add MultipleTasksTests

### DIFF
--- a/SwiftTask.xcodeproj/project.pbxproj
+++ b/SwiftTask.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		1FD7197B1AFE387C00BC38C4 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */; };
 		1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */; };
 		1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */; };
+		1FF95CB01CDD8F8D00899FEA /* MultipleTasksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF95CAF1CDD8F8D00899FEA /* MultipleTasksTests.swift */; };
+		1FF95CB11CDD8F8D00899FEA /* MultipleTasksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF95CAF1CDD8F8D00899FEA /* MultipleTasksTests.swift */; };
 		4822F0DC19D00B2300F5F572 /* _TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEFC199EE2C200F97868 /* _TestCase.swift */; };
 		4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F20250119ADA8FD00DE0495 /* BasicTests.swift */; };
 		4822F0DE19D00B2300F5F572 /* SwiftTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46DEE3199EDF1000F97868 /* SwiftTaskTests.swift */; };
@@ -76,6 +78,7 @@
 		1FCF71151AD8CD38007079C2 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = ../Carthage/Checkouts/Alamofire/build/Debug/Alamofire.framework; sourceTree = "<group>"; };
 		1FD7197A1AFE387C00BC38C4 /* Cancellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		1FF52EB31A4C395A00B4BA28 /* _InterruptableTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _InterruptableTask.swift; sourceTree = "<group>"; };
+		1FF95CAF1CDD8F8D00899FEA /* MultipleTasksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleTasksTests.swift; sourceTree = "<group>"; };
 		1FFADCCF1C5CE950000B66BE /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		1FFADCD01C5CE950000B66BE /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		1FFADCD11C5CE950000B66BE /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
@@ -174,6 +177,7 @@
 				1F218D5A1AFC3FFD00C849FF /* RemoveHandlerTests.swift */,
 				1F5FA35619A374E600975FB9 /* AlamofireTests.swift */,
 				1F29F6411B115EF500F476AF /* MultipleErrorTypesTests.swift */,
+				1FF95CAF1CDD8F8D00899FEA /* MultipleTasksTests.swift */,
 				1F46DEE1199EDF1000F97868 /* Supporting Files */,
 			);
 			path = SwiftTaskTests;
@@ -375,6 +379,7 @@
 				1F20250219ADA8FD00DE0495 /* BasicTests.swift in Sources */,
 				1FF52EB41A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
 				1F218D5B1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
+				1FF95CB01CDD8F8D00899FEA /* MultipleTasksTests.swift in Sources */,
 				1F6A8CA319A4E4F200369A5D /* SwiftTaskTests.swift in Sources */,
 				1F29F6421B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */,
 				1F4C76A41AD8CF40004E47C1 /* AlamofireTests.swift in Sources */,
@@ -391,6 +396,7 @@
 				4822F0DE19D00B2300F5F572 /* SwiftTaskTests.swift in Sources */,
 				4822F0DD19D00B2300F5F572 /* BasicTests.swift in Sources */,
 				1F218D5C1AFC3FFD00C849FF /* RemoveHandlerTests.swift in Sources */,
+				1FF95CB11CDD8F8D00899FEA /* MultipleTasksTests.swift in Sources */,
 				1FF52EB51A4C395A00B4BA28 /* _InterruptableTask.swift in Sources */,
 				1F29F6431B115EF500F476AF /* MultipleErrorTypesTests.swift in Sources */,
 				1F4C76A51AD8CF41004E47C1 /* AlamofireTests.swift in Sources */,

--- a/SwiftTaskTests/MultipleTasksTests.swift
+++ b/SwiftTaskTests/MultipleTasksTests.swift
@@ -1,0 +1,136 @@
+//
+//  MultipleTasksTests.swift
+//  SwiftTask
+//
+//  Created by Yasuhiro Inami on 2016-05-07.
+//  Copyright © 2016 Yasuhiro Inami. All rights reserved.
+//
+
+import SwiftTask
+import XCTest
+
+/// Generic type for value/error to demonstrate multiple tasks working on different types.
+private enum MyEnum<T> { case Default }
+
+private typealias Value1 = MyEnum<()>
+private typealias Error1 = MyEnum<Bool>
+private typealias Value2 = MyEnum<Float>
+private typealias Error2 = MyEnum<Double>
+private typealias Value3 = MyEnum<Int>
+private typealias Error3 = MyEnum<String>
+
+/// Wrapped error type to unify `Error1`/`Error2`/`Error3`.
+private enum WrappedError
+{
+    case ByTask1(Error1)
+    case ByTask2(Error2)
+    case ByTask3(Error3)
+
+    /// For external cancellation -> internal rejection conversion.
+    case Cancelled
+}
+
+class MultipleTasksTests: _TestCase
+{
+    func testMultipleTasksTests_success1_success2_success3()
+    {
+        let expect = self.expectationWithDescription(#function)
+
+        var flow = [Int]()
+
+        let task1 = { Task<(), Value1, Error1>(value: .Default).on(success: { _ in flow.append(1) }) }
+        let task2 = { Task<(), Value2, Error2>(value: .Default).on(success: { _ in flow.append(2) }) }
+        let task3 = { Task<(), Value3, Error3>(value: .Default).on(success: { _ in flow.append(3) }) }
+
+        task1()._mapError(WrappedError.ByTask1)
+            .success { _ in
+                task2()._mapError(WrappedError.ByTask2)
+            }
+            .success { _ in
+                task3()._mapError(WrappedError.ByTask3)
+            }
+            .on(success: { _ in
+                XCTAssertEqual(flow, [1, 2, 3])
+                expect.fulfill()
+            })
+
+        self.wait()
+    }
+
+    func testMultipleTasksTests_success1_success2_failure3()
+    {
+        let expect = self.expectationWithDescription(#function)
+
+        var flow = [Int]()
+
+        let task1 = { Task<(), Value1, Error1>(value: .Default).on(success: { _ in flow.append(1) }) }
+        let task2 = { Task<(), Value2, Error2>(value: .Default).on(success: { _ in flow.append(2) }) }
+        let task3 = { Task<(), Value3, Error3>(error: .Default).on(success: { _ in flow.append(3) }) }
+
+        task1()._mapError(WrappedError.ByTask1)
+            .success { _ in
+                task2()._mapError(WrappedError.ByTask2)
+            }
+            .success { _ in
+                task3()._mapError(WrappedError.ByTask3)
+            }
+            .on(failure: { error, isCancelled in
+                guard case let .Some(.ByTask3(error3)) = error else {
+                    XCTFail("Wrong WrappedError.")
+                    return
+                }
+                XCTAssertEqual(error3, Error3.Default)
+                XCTAssertEqual(flow, [1, 2])
+                expect.fulfill()
+            })
+        
+        self.wait()
+    }
+
+    func testMultipleTasksTests_success1_failure2_success3()
+    {
+        let expect = self.expectationWithDescription(#function)
+
+        var flow = [Int]()
+
+        let task1 = { Task<(), Value1, Error1>(value: .Default).on(success: { _ in flow.append(1) }) }
+        let task2 = { Task<(), Value2, Error2>(error: .Default).on(success: { _ in flow.append(2) }) }
+        let task3 = { Task<(), Value3, Error3>(value: .Default).on(success: { _ in flow.append(3) }) }
+
+        task1()._mapError(WrappedError.ByTask1)
+            .success { _ in
+                task2()._mapError(WrappedError.ByTask2)
+            }
+            .success { _ in
+                task3()._mapError(WrappedError.ByTask3)
+            }
+            .on(failure: { error, isCancelled in
+                guard case let .Some(.ByTask2(error2)) = error else {
+                    XCTFail("Wrong WrappedError.")
+                    return
+                }
+                XCTAssertEqual(error2, Error2.Default)
+                XCTAssertEqual(flow, [1])
+                expect.fulfill()
+            })
+        
+        self.wait()
+    }
+}
+
+extension Task
+{
+    /// Converts `Task<..., Error>` to `Task<..., WrappedError>`.
+    private func _mapError(f: Error -> WrappedError) -> Task<Progress, Value, WrappedError>
+    {
+        return self.failure { error, isCancelled -> Task<Progress, Value, WrappedError> in
+            if let error = error {
+                return Task<Progress, Value, WrappedError>(error: f(error))
+            }
+            else {
+                // converts external cancellation -> internal rejection
+                return Task<Progress, Value, WrappedError>(error: .Cancelled)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added multiple-tasks chaining example where each task has different `Value`/`Error` types.

This pull request is an answer for https://twitter.com/akio0911/status/728674545582804992 .
/cc @akio0911

Basic ideas are:
1. Create `enum WrappedError` for unifying different _type-strict_ error types (and add convenient method e.g. `_mapError`)
2. Keep chaining tasks using `func success()` and handle all results together at last using `func on(success:failure:)`
## Example Flow Chart

![](https://pbs.twimg.com/media/ChzFovQVIAAV2ZA.jpg)
