### PR TITLE
Add retry(_:condition:) method.

### DIFF
--- a/SwiftTask/SwiftTask.swift
+++ b/SwiftTask/SwiftTask.swift
@@ -185,6 +185,14 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         })
         self.name = "RejectedTask"
     }
+
+    private convenience init(_errorInfo: ErrorInfo)
+    {
+        self.init(_initClosure: { _, progress, fulfill, _reject, configure in
+            _reject(_errorInfo)
+        })
+        self.name = "RejectedTask"
+    }
     
     ///
     /// Create promise-like task which only allows fulfill & reject (no progress & configure)
@@ -310,32 +318,24 @@ public class Task<Progress, Value, Error>: Cancellable, CustomStringConvertible
         clonedTask.name = "\(self.name)-clone"
         return clonedTask
     }
-    
+
     /// Returns new task that is retryable for `maxRetryCount (= maxTryCount-1)` times.
-    public func retry(maxRetryCount: Int) -> Task
+    /// - Parameter condition: Predicate that will be evaluated on each retry timing.
+    public func retry(maxRetryCount: Int, condition: (ErrorInfo -> Bool) = { _ in true }) -> Task
     {
-        return retry(maxRetryCount, errorInfo: nil) { _ in true }
-    }
-    
-    /// Returns new task that is retryable for `maxRetryCount (= maxTryCount-1)` times.
-    /// Predicated condition will evaluate when each retry timing to handle retryable.
-    public func retry(maxRetryCount: Int, condition predicate: ErrorInfo -> Bool) -> Task
-    {
-        return retry(maxRetryCount, errorInfo: nil, condition: predicate)
-    }
-    
-    private func retry(maxRetryCount: Int, errorInfo: ErrorInfo?, condition predicate: ErrorInfo -> Bool) -> Task
-    {
-        if maxRetryCount < 1 { return self }
-        // Skip evaluation on first try. It is not retry.
-        if let errorInfo = errorInfo where !predicate(errorInfo) { return self }
-        
+        guard maxRetryCount > 0 else { return self }
+
         return Task { machine, progress, fulfill, _reject, configure in
             
             let task = self.progress { _, progressValue in
                 progress(progressValue)
             }.failure { [unowned self] errorInfo -> Task in
-                return self.clone().retry(maxRetryCount-1, errorInfo: errorInfo, condition: predicate) // clone & try recursively
+                if condition(errorInfo) {
+                    return self.clone().retry(maxRetryCount-1, condition: condition) // clone & try recursively
+                }
+                else {
+                    return Task(_errorInfo: errorInfo)
+                }
             }
                 
             task.progress { _, progressValue in

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -910,7 +910,7 @@ class SwiftTaskTests: _TestCase
             
         }.retry(maxTryCount-1) { error, isCancelled -> Bool in
             XCTAssertNotEqual(error!, "ERROR 0", "Should not evaluate retry condition on first try. It is not retry.")
-            return actualTryCount < 2
+            return actualTryCount < 3
         }.failure { error, isCancelled -> String in
             
             XCTAssertEqual(error!, "ERROR 3")

--- a/SwiftTaskTests/SwiftTaskTests.swift
+++ b/SwiftTaskTests/SwiftTaskTests.swift
@@ -908,7 +908,8 @@ class SwiftTaskTests: _TestCase
                 reject("ERROR \(actualTryCount)")
             }
             
-        }.retry(maxTryCount-1) { () -> Bool in
+        }.retry(maxTryCount-1) { error, isCancelled -> Bool in
+            XCTAssertNotEqual(error!, "ERROR 0", "Should not evaluate retry condition on first try. It is not retry.")
             return actualTryCount < 2
         }.failure { error, isCancelled -> String in
             


### PR DESCRIPTION
Hi, I want conditional retryable feature.
In my use case, I want retry failed task with date time predication like this.

```
task.retry(5) { () -> Bool in
  let now = NSDate()
  return now.compare(expireDate) == .OrderedAscending
}.success { (value) -> Void in
 ...
```

What do you think about this?
